### PR TITLE
not depth:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js: stable
 cache: npm
-git:
-  depth: false
 
 script:
   - npm run test


### PR DESCRIPTION
I'm curious how Travis deals differently with this. Seems that a shallow clone is the default, but perhaps I'm reading the docs wrong. 