### PR TITLE
Enforce uniqueness of example titles

### DIFF
--- a/scripts/build-json/compose-examples.js
+++ b/scripts/build-json/compose-examples.js
@@ -40,7 +40,25 @@ function packageExample(examplePath) {
 }
 
 function package(paths) {
-    return paths.map(packageExample);
+    const rendered = paths.map(packageExample);
+
+    // Do invariance checking after all examples have been packaged.
+    // These are checks that only makes sense to run *after* all
+    // individual examples have been packaged.
+    const normalizedTitles = new Set(
+        rendered.map(example => example.description.title)
+        .filter(title => !!title)
+        .map(title => title.trim().toLowerCase())
+    );
+    // Check that they are all unique
+    if (normalizedTitles.size !== rendered.length) {
+        throw new Error(
+            "Every example's description title must be unique " +
+            `(${JSON.stringify([...normalizedTitles])})`
+        );
+    }
+
+    return rendered
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes #47

First all, to test this I messed with the `.md` files temporarily. Looked like this:
<img width="339" alt="Screen Shot 2019-06-04 at 10 54 47 AM" src="https://user-images.githubusercontent.com/26739/58889760-6e596400-86b7-11e9-98d1-2e03426e2e33.png">

Now you get this:
```
▶ npm run build-json video

> stump@0.1.0 build-json /Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment
> node scripts/build-json/build-json.js "video"

/Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment/scripts/build-json/compose-examples.js:58
        throw new Error(
        ^

Error: Every example's description title must be unique (["generic title"])
    at Object.package (/Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment/scripts/build-json/compose-examples.js:58:15)
    at Object.buildPageJSON (/Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment/scripts/build-json/build-page-json.js:60:33)
    at buildJSON (/Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment/scripts/build-json/build-json.js:37:29)
    at Object.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/stumptown-experiment/scripts/build-json/build-json.js:42:14)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
```

There is a more important discussion to be had. We *could* **not** do this and instead put code like this in some other place. Instead of doing it in `compose-example.js` it could be done as an "extension" to `build-json.js`. 

For example, the `buildPageJSON` function (in `build-page-json.js`) has this idea of putting together an Object and then writing that to disk. Within the function it does some checks (arguably not related to the actual content much) and then returns a different error other than 0. For example, in [`buildPageJSON()`](https://github.com/mdn/stumptown-experiment/blob/9b706592a12a1c79f6a6e1ced9e9e7d134f3d0c3/scripts/build-json/build-page-json.js#L60)
it does this:
```javascript
element.examples = examples.package(examplesPaths);
```
We could change that to:
```javascript
element.examples = examples.package(examplesPaths);
validateExamples(element.examples);
```

The same effort needs to be done but it's a matter of code layout where we put that business logic. I think I prefer to do that kinda stuff near and close to the code that generates and raise exceptions as early as possible. After all, if you do throw exceptions you can still rewrite the surrounding tooling to work like this:

```javascript
for (let item of items) {
    try {
        errors += buildPage.buildPageJSON(item);
    } catch(exc) {
        console.warn(`Failed to build ${item}`);
       errors += 1;
    }
}
```