### PR TITLE
Add first version of a tool to help migrate pages from MDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,11 @@
             "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
         },
+        "array-iterate": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.3.tgz",
+            "integrity": "sha512-7MIv7HE9MuzfK6B2UnWv07oSHBLOaY1UUXAxZ07bIeRM+4IkPTlveMDs9MY//qvxPZPSvCn2XV4bmtQgSkVodg=="
+        },
         "array-union": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -446,6 +451,11 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "comma-separated-tokens": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
+            "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
         },
         "commander": {
             "version": "2.19.0",
@@ -914,8 +924,7 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -933,13 +942,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -952,18 +959,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1066,8 +1070,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1077,7 +1080,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1090,20 +1092,17 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -1120,7 +1119,6 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1193,8 +1191,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1204,7 +1201,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -1280,8 +1276,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -1311,7 +1306,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -1329,7 +1323,6 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -1368,13 +1361,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.2",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 }
             }
         },
@@ -1512,6 +1503,89 @@
                 }
             }
         },
+        "hast-util-embedded": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.4.tgz",
+            "integrity": "sha512-kfCMiRzYPWx9I6KYdW5DCS+WM6xRmAtfrPd2yEG+5cuwquEh0Qh2sV7CX0tbdes/nmm2lBTGLURh0GmRb2txgQ==",
+            "requires": {
+                "hast-util-is-element": "^1.0.0"
+            }
+        },
+        "hast-util-from-parse5": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.1.tgz",
+            "integrity": "sha512-UfPzdl6fbxGAxqGYNThRUhRlDYY7sXu6XU9nQeX4fFZtV+IHbyEJtd+DUuwOqNV4z3K05E/1rIkoVr/JHmeWWA==",
+            "requires": {
+                "ccount": "^1.0.3",
+                "hastscript": "^5.0.0",
+                "property-information": "^5.0.0",
+                "web-namespaces": "^1.1.2",
+                "xtend": "^4.0.1"
+            }
+        },
+        "hast-util-has-property": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.3.tgz",
+            "integrity": "sha512-tT3ffSnrBu38RKnjn27n9vi+h/CUEXCQP5O2mriji4NNI2QNnhAqefjOg5ORAyvVfJItn0SC2Sx4CHReZSYh3g=="
+        },
+        "hast-util-is-body-ok-link": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.2.tgz",
+            "integrity": "sha512-eSxO9rgtb7dfKxNa8NAFS3VEYWHXnJWVsoH/Z4jSsq1J2i4H1GkdJ43kXv++xuambrtI5XQwcAx6jeZVMjoBMQ==",
+            "requires": {
+                "hast-util-has-property": "^1.0.0",
+                "hast-util-is-element": "^1.0.0"
+            }
+        },
+        "hast-util-is-element": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
+            "integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA=="
+        },
+        "hast-util-parse-selector": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
+            "integrity": "sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw=="
+        },
+        "hast-util-to-mdast": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-5.0.0.tgz",
+            "integrity": "sha512-+cAQpVOtGrxdRIZGBQKLToqinPAtC5tZH0PRy9iYubmwnMNF0d96YaUbrMiYEEQezNQ60CGzaGTM0BBJcnViAA==",
+            "requires": {
+                "extend": "^3.0.2",
+                "hast-util-has-property": "^1.0.0",
+                "hast-util-is-element": "^1.0.0",
+                "hast-util-to-text": "^1.0.0",
+                "mdast-util-phrasing": "^1.0.0",
+                "mdast-util-to-string": "^1.0.4",
+                "rehype-minify-whitespace": "^2.0.3",
+                "repeat-string": "^1.6.1",
+                "trim-trailing-lines": "^1.1.0",
+                "unist-util-visit": "^1.1.1",
+                "xtend": "^4.0.1"
+            }
+        },
+        "hast-util-to-text": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-1.0.1.tgz",
+            "integrity": "sha512-Xvp9fWiWVb4WaHc1E1g6dtyYlcVwyjRT0CC9oXtVUNhbmIB1gqRVBuBIFJgrFkYxdo+T3UIl5i5ipPGaPRnUOw==",
+            "requires": {
+                "hast-util-is-element": "^1.0.2",
+                "repeat-string": "^1.6.1",
+                "unist-util-find-after": "^2.0.3"
+            }
+        },
+        "hastscript": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.0.tgz",
+            "integrity": "sha512-7mOQX5VfVs/gmrOGlN8/EDfp1GqV6P3gTNVt+KnX4gbYhpASTM8bklFdFQCbFRAadURXAmw0R1QQdBdqp7jswQ==",
+            "requires": {
+                "comma-separated-tokens": "^1.0.0",
+                "hast-util-parse-selector": "^2.2.0",
+                "property-information": "^5.0.1",
+                "space-separated-tokens": "^1.0.0"
+            }
+        },
         "html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -1519,6 +1593,11 @@
             "requires": {
                 "whatwg-encoding": "^1.0.1"
             }
+        },
+        "html-whitespace-sensitive-tag-names": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.1.tgz",
+            "integrity": "sha512-TMdAWVry7Ld0k2sLqpHkWsFAHmU+VZZq/nR4bfwfxThD8q3ibhrpRTywyQkEiunYiZXmJ6gRcJiLbZm+jbQPgQ=="
         },
         "http-signature": {
             "version": "1.2.0",
@@ -2055,6 +2134,21 @@
             "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-1.0.4.tgz",
             "integrity": "sha512-n4fUvwpR5Uj1Ti658KxYDq9gR0UF3FK1UVTVig12imrSOssQU2OpUysje8nps5Cb85b6eau5akpWW7Zkxtv1XA=="
         },
+        "mdast-util-phrasing": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-1.0.3.tgz",
+            "integrity": "sha512-b1Ar28MjmPMMnTDUApnL1AUJY1L/KmBg5+iBLMd8/+0JqXh1sENow9+wj8Mp/SZBYtMlGRUQ1PkBWinPEDVeNQ==",
+            "requires": {
+                "unist-util-is": "^3.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+                    "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+                }
+            }
+        },
         "mdast-util-to-string": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz",
@@ -2171,6 +2265,11 @@
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
             "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "normalize-path": {
             "version": "2.1.1",
@@ -2408,6 +2507,14 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
+        "property-information": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.1.0.tgz",
+            "integrity": "sha512-tODH6R3+SwTkAQckSp2S9xyYX8dEKYkeXw+4TmJzTxnNzd6mQPu1OD4f9zPrvw/Rm4wpPgI+Zp63mNSGNzUgHg==",
+            "requires": {
+                "xtend": "^4.0.1"
+            }
+        },
         "psl": {
             "version": "1.1.32",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
@@ -2465,6 +2572,46 @@
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
+            }
+        },
+        "rehype-minify-whitespace": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-2.0.4.tgz",
+            "integrity": "sha512-TQVOvOSURaWNbYepVgSzUofSTRsaAVQe/dH01Mo44u+Gr221jTmUem8l0jlJBAfSOHNaUF4jfDDbyEeb4ueAmA==",
+            "requires": {
+                "collapse-white-space": "^1.0.0",
+                "hast-util-embedded": "^1.0.0",
+                "hast-util-has-property": "^1.0.0",
+                "hast-util-is-body-ok-link": "^1.0.0",
+                "hast-util-is-element": "^1.0.0",
+                "html-whitespace-sensitive-tag-names": "^1.0.0",
+                "unist-util-is": "^3.0.0",
+                "unist-util-modify-children": "^1.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+                    "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+                }
+            }
+        },
+        "rehype-parse": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
+            "integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
+            "requires": {
+                "hast-util-from-parse5": "^5.0.0",
+                "parse5": "^5.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "rehype-remark": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-6.0.0.tgz",
+            "integrity": "sha512-gERmKDCIwZiZqjtHDpPF+2zq/A2OrCkVoa/DcNUNtsdfbDK8UH6elnxse5ZrzNlHIOWrAGODtQG+4mO9GbGYCQ==",
+            "requires": {
+                "hast-util-to-mdast": "^5.0.0"
             }
         },
         "remark": {
@@ -3219,6 +3366,11 @@
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
+        "space-separated-tokens": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
+            "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+        },
         "spawn-sync": {
             "version": "1.0.15",
             "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
@@ -3616,6 +3768,21 @@
             "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
             "integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI="
         },
+        "unist-util-find-after": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-2.0.4.tgz",
+            "integrity": "sha512-zo0ShIr+E/aU9xSK7JC9Kb+WP9seTFCuqVYdo5+HJSjN009XMfhiA1FIExEKzdDP1UsgvKGleGlB/pSdTSqZww==",
+            "requires": {
+                "unist-util-is": "^3.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+                    "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+                }
+            }
+        },
         "unist-util-generated": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.3.tgz",
@@ -3633,6 +3800,14 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
             "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+        },
+        "unist-util-modify-children": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.4.tgz",
+            "integrity": "sha512-8iey9wkoB62C7Vi/8zcRUmi4b1f5AYKTwMkyEgLduo2D8+OY65RoSvbn6k9tVNri6qumXxAwXDVlXWQi0sENTw==",
+            "requires": {
+                "array-iterate": "^1.0.0"
+            }
         },
         "unist-util-position": {
             "version": "3.0.2",
@@ -3838,6 +4013,11 @@
             "requires": {
                 "browser-process-hrtime": "^0.1.2"
             }
+        },
+        "web-namespaces": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
+            "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
         },
         "webidl-conversions": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "prettify": "prettier --write scripts/**/*.js",
         "lint-md": "remark -q -f content",
         "build-json": "node scripts/build-json/build-json.js",
+        "scrape-mdn": "node scripts/scraper/scrape-mdn.js",
         "spell-md": "mdspell -a -n -r -x --en-us 'content/**/!(*contributors).md'",
         "test": "npm run lint-md && npm run spell-md"
     },
@@ -27,10 +28,14 @@
         "markdown-spellcheck": "1.3.1",
         "marked": "0.6.2",
         "mdn-browser-compat-data": "0.x",
+        "node-fetch": "2.6.0",
+        "rehype-parse": "6.0.0",
+        "rehype-remark": "6.0.0",
         "remark-cli": "6.0.1",
         "remark-frontmatter": "^1.3.1",
         "remark-preset-lint-consistent": "^2.0.2",
-        "remark-preset-lint-recommended": "3.0.2"
+        "remark-preset-lint-recommended": "3.0.2",
+        "remark-stringify": "6.0.4"
     },
     "remarkConfig": {
         "plugins": [

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -45,13 +45,6 @@ function toMarkdown(html) {
 }
 
 /**
- * Converts a document title into a filename.
- */
-function namify(title) {
-  return title.toLowerCase().replace(/[ ?]/gi, "-");
-}
-
-/**
  * Just writes the doc out where we want.
  */
 function writeDoc(subpath, name, doc) {
@@ -108,7 +101,7 @@ async function processDoc(relativeURL, title, destination) {
   const absoluteURL = baseURL + relativeURL;
   const md = String(await processSingleDocContent(absoluteURL));
   const doc = addFrontMatter(title, relativeURL, md);
-  writeDoc(destination, namify(title), doc);
+  writeDoc(destination, relativeURL.split('/').pop(), doc);
 }
 
 /**

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -5,36 +5,18 @@ Usage:
 
 npm run scrape-mdn <mdn-url> <destination> scrape-children
 
-<mdn-url>
-A full URL to an MDN page to scrape.
+<mdn-url>: A full URL to an MDN page to scrape.
 
-<destination>
-Where to put the processed document. This is relative to ./content
+<destination>: Where to put the processed document. This is relative to ./content
 
-scrape-children
-If 'scrape-children' is given, fetch the immediate children of this page and process them as well.
-Store the child pages under a subdirectory of <destination>, where the subdirectory
-name is the parent's name.
-
-For example, if you call:
-
-npm run scrape-mdn https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding learn/html scrape-children
-
-...this will fetch and process the page at
-https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding
-and all its immediate children.
-
-The page at 'Multimedia_and_embedding' will
-be saved as './content/learn/html/multimedia-and-embedding.md'.
-
-Its children will
-be saved as pages like ./content/learn/html/Multimedia_and_embedding/images-in-html.md.
+scrape-children: If 'scrape-children' is given, fetch the immediate children
+of this page and process them as well. Store the child pages under a
+subdirectory of <destination>, where the subdirectory name is the parent's name.
 
 The pages are 'processed' on the way. This means that they are:
 * converted to JSDOM where various things can be done to them, before going back to HTML
 * converted to Markdown
 * given some front matter (title and mdn_url)
-
 */
 
 const unified = require('unified');

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -1,0 +1,151 @@
+/*
+A scraper to help migrate MDN docs to stumptown.
+
+Usage:
+
+npm run scrape-mdn <mdn-url> <destination> scrape-children
+
+<mdn-url>
+A full URL to an MDN page to scrape.
+
+<destination>
+Where to put the processed document. This is relative to ./content
+
+scrape-children
+If 'scrape-children' is given, fetch the immediate children of this page and process them as well.
+Store the child pages under a subdirectory of <destination>, where the subdirectory
+name is the parent's name.
+
+For example, if you call:
+
+npm run scrape-mdn https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding learn/html scrape-children
+
+...this will fetch and process the page at
+https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding
+and all its immediate children.
+
+The page at 'Multimedia_and_embedding' will
+be saved as './content/learn/html/multimedia-and-embedding.md'.
+
+Its children will
+be saved as pages like ./content/learn/html/Multimedia_and_embedding/images-in-html.md.
+
+The pages are 'processed' on the way. This means that they are:
+* converted to JSDOM where various things can be done to them, before going back to HTML
+* converted to Markdown
+* given some front matter (title and mdn_url)
+
+*/
+
+const unified = require('unified');
+const parse = require('rehype-parse');
+const stringify = require('remark-stringify');
+const rehype2remark = require('rehype-remark');
+
+const fetch = require("node-fetch");
+const fs = require('fs');
+const path = require('path');
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+
+const baseURL = 'https://developer.mozilla.org';
+
+/**
+ * Converts the HTML -> Markdown using unified.
+ */
+function toMarkdown(html) {
+  return unified()
+    .use(parse)
+    .use(rehype2remark)
+    .use(stringify)
+    .process(html);
+}
+
+/**
+ * Converts a document title into a filename.
+ */
+function namify(title) {
+  return title.toLowerCase().replace(/[ ?]/gi, "-");
+}
+
+/**
+ * Just writes the doc out where we want.
+ * 'subpath' is placed under './content'.
+ */
+function writeDoc(subpath, name, doc) {
+  const dest = path.join(process.cwd(), 'content', subpath, `${name}.md`);
+  const destDir = path.dirname(dest);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  fs.writeFileSync(dest, doc);
+}
+
+function addFrontMatter(title, url, md) {
+  const fullURL = `${baseURL}${url}`;
+  return `---\ntitle: ${title}\nmdn_url: ${fullURL}\n---\n${md}`;
+}
+
+/**
+ * 1. Convert the given HTML to JSDOM
+ * 2. Do any cleaning we want
+ * 3. Serialize the result back to HTML
+ */
+function cleanHTML(html) {
+  const dom = new JSDOM(html);
+  const sidebar = dom.window.document.querySelector('section.Quick_links');
+  if (sidebar) {
+    sidebar.parentNode.removeChild(sidebar);
+  }
+  return dom.serialize();
+}
+
+/**
+ * 1. Get the raw HTML from the given url.
+ * 2. Pass the HTML to the cleaner
+ * 3. Convert the clean HTML to Markdown and return it.
+ */
+function processSingleDocContent(mdnURL) {
+  const mdnRaw = mdnURL + '?raw&macros';
+  return fetch(mdnRaw)
+    .then(result => result.text())
+    .then(text => cleanHTML(text))
+    .then(text => toMarkdown(text));
+}
+
+function getPageJSON(url) {
+  return fetch(url).then(result => result.json());
+}
+
+/**
+ * 1. Get cleaned and converted Markdown from MDN
+ * 2. Add front matter
+ * 3. Save the resulting content to a file.
+ */
+async function processDoc(relativeURL, title, destination) {
+  const absoluteURL = baseURL + relativeURL;
+  const md = String(await processSingleDocContent(absoluteURL));
+  const doc = addFrontMatter(title, relativeURL, md);
+  writeDoc(destination, namify(title), doc);
+}
+
+/**
+ * If 'scrape-children' was passed, scrape the children of the given page
+ * and process them as well as the parent.
+ * Otherwise just process the given page.
+ */
+async function main(args) {
+  if (args.length > 2 && args[2] === 'scrape-children') {
+    const childrenJSON = await getPageJSON(args[0] + '$children');
+    childrenJSON.subpages.map(child => {
+      // the final component of the parent's URL
+      // is used as a subdirectory for the children
+      const subpath = args[0].split('/').pop();
+      processDoc(child.url, child.title, path.join(args[1], subpath));
+    });
+  }
+  const docJSON = await getPageJSON(args[0] + '$json');
+  processDoc(docJSON.url, docJSON.title, args[1]);
+}
+
+main(process.argv.slice(2));

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -3,13 +3,14 @@ A scraper to help migrate MDN docs to stumptown.
 
 Usage:
 
-npm run scrape-mdn <mdn-url> <destination> scrape-children
+npm run scrape-mdn <mdn-url> <destination> -- --scrape-children
 
 <mdn-url>: A full URL to an MDN page to scrape.
 
-<destination>: Where to put the processed document. This is relative to ./content
+<destination>: Where to put the processed document. This is relative to the current
+working directory.
 
-scrape-children: If 'scrape-children' is given, fetch the immediate children
+--scrape-children: If '--scrape-children' is given, fetch the immediate children
 of this page and process them as well. Store the child pages under a
 subdirectory of <destination>, where the subdirectory name is the parent's name.
 
@@ -52,10 +53,9 @@ function namify(title) {
 
 /**
  * Just writes the doc out where we want.
- * 'subpath' is placed under './content'.
  */
 function writeDoc(subpath, name, doc) {
-  const dest = path.join(process.cwd(), 'content', subpath, `${name}.md`);
+  const dest = path.join(process.cwd(), subpath, `${name}.md`);
   const destDir = path.dirname(dest);
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir, { recursive: true });
@@ -117,7 +117,7 @@ async function processDoc(relativeURL, title, destination) {
  * Otherwise just process the given page.
  */
 async function main(args) {
-  if (args.length > 2 && args[2] === 'scrape-children') {
+  if (args.includes('--scrape-children')) {
     const childrenJSON = await getPageJSON(args[0] + '$children');
     childrenJSON.subpages.map(child => {
       // the final component of the parent's URL


### PR DESCRIPTION
This is the first iteration of a scraper to help migrate MDN docs to stumptown.

Usage:

    npm run scrape-mdn <mdn-url> <destination> scrape-children

`<mdn-url>`
A full URL to an MDN page to scrape.

`<destination>`
Where to put the processed document. This is relative to ./content

`scrape-children`
If 'scrape-children' is given, fetch the immediate children of this page and process them as well.
Store the child pages under a subdirectory of `<destination>`, where the subdirectory name is the parent's name.

For example, if you call:

    npm run scrape-mdn https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding learn/html scrape-children

...this will fetch and process the page at
https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding
and all its immediate children.

The page at 'Multimedia_and_embedding' will
be saved as './content/learn/html/multimedia-and-embedding.md'.

Its children will be saved as pages like ./content/learn/html/Multimedia_and_embedding/images-in-html.md.

The pages are 'processed' on the way. This means that they are:
* converted to JSDOM where various things can be done to them, before going back to HTML
* converted to Markdown
* given some front matter (title and mdn_url)

Of course we could extend the processing to do other interesting things.