### PR TITLE
end-to-end test in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 node_js: stable
-
+cache: npm
 git:
   depth: false
+
+script:
+  - npm run test
+  # Note, in a near future we're going to want to build-json for *everything*
+  # and not just the 'html' section.
+  - npm run build-json html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # stumptown-experiment
 
+[![Build Status](https://travis-ci.org/mdn/stumptown-content.svg?branch=master)](https://travis-ci.org/mdn/stumptown-content)
+
 ## Installation
 
 First [fork](https://help.github.com/en/articles/fork-a-repo) then [clone the repo on your machine](https://help.github.com/en/articles/cloning-a-repository-from-github).


### PR DESCRIPTION
Context is that after this I'd like to pull in `stumptown-renderer` in CI. There are two interesting things that can come out of that. 

A) We would constantly check the "contract" between content and renderer. In the renderer we are specific about which version of the content we want to use and it's not always `master`. When you're changing that "contract" you might not want to block the PR because the renderer isn't yet ready for this change. So when we do execute the renderer from `stumptown-content`'s CI we probably only want to yield a warning. 

B) If the renderer can render this version of the content we can ship that whole static site to a staging URL on netlify. Then you can fully preview your content changes. 