### PR TITLE
Remove wrapping from built JSON

### DIFF
--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -39,28 +39,25 @@ async function buildPageJSON(elementRelativePath) {
     const prosePath = path.join(elementPath, 'prose.md');
     const contributorsPath = path.join(elementPath, 'contributors.md');
 
-    // set up element data
-    const element = {
-      data: {},
-      metadata: {}
-    };
-    element.data.title = meta.title;
-    element.data.mdn_url = meta['mdn-url'];
-    element.data.interactive_example_url = meta['interactive-example'];
-    element.data.browser_compatibility = bcd.package(meta['browser-compatibility']);
+    // set up data
+    const data = {};
+    data.title = meta.title;
+    data.mdn_url = meta['mdn-url'];
+    data.interactive_example_url = meta['interactive-example'];
+    data.browser_compatibility = bcd.package(meta['browser-compatibility']);
     if (meta.attributes['element-specific']) {
         const attributesPath = path.join(elementPath, meta.attributes['element-specific']);
-        element.data.attributes = await attributes.package(attributesPath);
+        data.attributes = await attributes.package(attributesPath);
     } else {
-        element.data.attributes = [];
+        data.attributes = [];
     }
-    element.data.examples = await examples.package(examplesPaths);
-    element.data.prose = await prose.package(prosePath);
+    data.examples = await examples.package(examplesPaths);
+    data.prose = await prose.package(prosePath);
 
     // set up element metadata
-    element.metadata.contributors = await contributors.package(contributorsPath);
+    data.contributors = await contributors.package(contributorsPath);
 
-    writeToFile(element, elementRelativePath);
+    writeToFile(data, elementRelativePath);
     console.log(`Processed: ${elementRelativePath}`);
     return 0;
 }

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -8,23 +8,15 @@ const attributes = require('./compose-attributes');
 const prose = require('./slice-prose');
 const contributors = require('./resolve-contributors');
 
-const writeToFile = (json, elementPath) => {
+function writeToFile(json, elementPath) {
   const propertyName = path.basename(elementPath);
   const dirName = path.dirname(elementPath);
-  const data = {
-    html: {
-      elements: {
-        [propertyName]: json,
-      }
-    }
-  };
-
   const dest = path.join(process.cwd(), 'packaged', dirName, `${propertyName}.json`);
   const destDir = path.dirname(dest);
   if (!fs.existsSync(destDir)) {
       fs.mkdirSync(destDir, { recursive: true });
   }
-  fs.writeFileSync(dest, `${JSON.stringify(data, null, 2)}`);
+  fs.writeFileSync(dest, `${JSON.stringify(json, null, 2)}`);
 };
 
 async function buildPageJSON(elementRelativePath) {
@@ -47,21 +39,26 @@ async function buildPageJSON(elementRelativePath) {
     const prosePath = path.join(elementPath, 'prose.md');
     const contributorsPath = path.join(elementPath, 'contributors.md');
 
-    // make the package
-    const element = {};
-    element.title = meta.title;
-    element.mdn_url = meta['mdn-url'];
-    element.interactive_example_url = meta['interactive-example'];
-    element.browser_compatibility = bcd.package(meta['browser-compatibility']);
+    // set up element data
+    const element = {
+      data: {},
+      metadata: {}
+    };
+    element.data.title = meta.title;
+    element.data.mdn_url = meta['mdn-url'];
+    element.data.interactive_example_url = meta['interactive-example'];
+    element.data.browser_compatibility = bcd.package(meta['browser-compatibility']);
     if (meta.attributes['element-specific']) {
         const attributesPath = path.join(elementPath, meta.attributes['element-specific']);
-        element.attributes = await attributes.package(attributesPath);
+        element.data.attributes = await attributes.package(attributesPath);
     } else {
-        element.attributes = [];
+        element.data.attributes = [];
     }
-    element.examples = await examples.package(examplesPaths);
-    element.prose = await prose.package(prosePath);
-    element.contributors = await contributors.package(contributorsPath);
+    element.data.examples = await examples.package(examplesPaths);
+    element.data.prose = await prose.package(prosePath);
+
+    // set up element metadata
+    element.metadata.contributors = await contributors.package(contributorsPath);
 
     writeToFile(element, elementRelativePath);
     console.log(`Processed: ${elementRelativePath}`);


### PR DESCRIPTION
This PR remove the "html.elements.*" wrapping from the built JSON.

It also splits the content between `data` and `metadata`. As discussed in https://github.com/mdn/stumptown-content/pull/70#issuecomment-510909281 and following, `metadata` currently contains just `contributors` but might also include `recipe` depending on how people feel about https://github.com/mdn/stumptown-content/issues/68, and might also include `modified_data` if we want to support that.
