### PR TITLE
References #89 - Fix HTML content to match new recipe

### DIFF
--- a/content/html/reference/elements/abbr/docs.md
+++ b/content/html/reference/elements/abbr/docs.md
@@ -24,7 +24,7 @@ recipe: html-element
 The **HTML Abbreviation element** (**`<abbr>`**) represents an
 abbreviation or acronym.
 
-## Usage notes
+## Overview
 
 The article *[How to mark abbreviations and make them
 understandable](/en-US/Learn/HTML/Howto/Mark_abbreviations_and_make_them_understandable)*

--- a/content/html/reference/elements/address/docs.md
+++ b/content/html/reference/elements/address/docs.md
@@ -37,8 +37,6 @@ business\'s contact information in the page header, or indicating the
 author of an article by including an `<address>` element within the
 [`<article>`](/en-US/docs/Web/HTML/Element/article "The HTML <article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry.").
 
-## Usage notes
-
 - To represent an arbitrary address, one that is not related to the
   contact information, use a
   [`<p>`](/en-US/docs/Web/HTML/Element/p)

--- a/content/html/reference/elements/article/docs.md
+++ b/content/html/reference/elements/article/docs.md
@@ -35,8 +35,6 @@ blog that shows the text of each article one after another as the reader
 scrolls, each post would be contained in an `<article>` element,
 possibly with one or more `<section>`s within.
 
-## Usage notes
-
 - Each `<article>` should be identified, typically by including a heading
   ([`<h1>`-`<h6>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
   element) as a child of the `<article>` element.

--- a/content/html/reference/elements/aside/docs.md
+++ b/content/html/reference/elements/aside/docs.md
@@ -24,10 +24,11 @@ recipe: html-element
 
 The **HTML `<aside>` element** represents a portion of a document whose
 content is only indirectly related to the document's main
-content. Asides are frequently presented as sidebars or
-call-out boxes.
+content.
 
-## Usage notes
+## Overview
+
+Asides are frequently presented as sidebars or call-out boxes.
 
 - Do not use the `<aside>` element to tag parenthesized text, as this
   kind of text is considered part of the main flow.

--- a/content/html/reference/elements/audio/docs.md
+++ b/content/html/reference/elements/audio/docs.md
@@ -29,6 +29,7 @@ the destination for streamed media, using a
 [`MediaStream`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream).
 
 ## Overview
+
 In a similar manner to the
 [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
 element, we include a path to the media we want to embed inside the
@@ -76,8 +77,6 @@ A good general source of information on using HTML `<audio>` is the
 [Video and audio
 content](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 beginner's tutorial.
-
-## Usage notes
 
 ### Styling with CSS
 

--- a/content/html/reference/elements/b/docs.md
+++ b/content/html/reference/elements/b/docs.md
@@ -33,8 +33,6 @@ property to create boldface text, or the
 [`<strong>`](/en-US/docs/Web/HTML/Element/strong)
 element to indicate that text is of special importance.
 
-## Usage notes
-
 - Use the `<b>` for cases like keywords in a summary, product names in
   a review, or other spans of text whose typical presentation would be
   boldfaced (but not including any special importance).

--- a/content/html/reference/elements/base/docs.md
+++ b/content/html/reference/elements/base/docs.md
@@ -26,7 +26,5 @@ relative URLs contained within a document. There can be only one
 The base URL of a document can be queried from a script using
 [`document.baseURI`](/en-US/docs/Web/API/Document/baseURI).
 
-## Usage notes
-
 If multiple `<base>` elements are specified, only the first `href` and
 first `target` value are used; all others are ignored.

--- a/content/html/reference/elements/blockquote/docs.md
+++ b/content/html/reference/elements/blockquote/docs.md
@@ -18,15 +18,15 @@ recipe: html-element
 ## Short description
 
 The **HTML `<blockquote>` Element** (or *HTML Block Quotation Element*)
-indicates that the enclosed text is an extended quotation. Usually, this
-is rendered visually by indentation (see [Usage notes](#Usage_notes) for how
-to change it). A URL for the source of the quotation may be given using
-the **cite** attribute, while a text representation of the source can be
-given using the
-[`<cite>`](/en-US/docs/Web/HTML/Element/cite)
-element.
+indicates that the enclosed text is an extended quotation.
 
-## Usage notes
+## Overview
+
+Usually, this is rendered visually by indentation (see
+[Usage notes](#Usage_notes) for how to change it). A URL for the source of the
+quotation may be given using the **cite** attribute, while a text representation
+of the source can be given using the
+[`<cite>`](/en-US/docs/Web/HTML/Element/cite) element.
 
 To change the indentation applied to the quoted text, use the
 [CSS](/en-US/docs/Glossary/CSS")

--- a/content/html/reference/elements/blockquote/docs.md
+++ b/content/html/reference/elements/blockquote/docs.md
@@ -22,8 +22,7 @@ indicates that the enclosed text is an extended quotation.
 
 ## Overview
 
-Usually, this is rendered visually by indentation (see
-[Usage notes](#Usage_notes) for how to change it). A URL for the source of the
+Usually, this is rendered visually by indentation. A URL for the source of the
 quotation may be given using the **cite** attribute, while a text representation
 of the source can be given using the
 [`<cite>`](/en-US/docs/Web/HTML/Element/cite) element.

--- a/content/html/reference/elements/body/docs.md
+++ b/content/html/reference/elements/body/docs.md
@@ -17,7 +17,11 @@ recipe: html-element
 ## Short description
 
 The **HTML `<body>` Element** represents the content of an HTML
-document. There can be only one `<body>` element in a document.
+document.
+
+## Overview
+
+There can be only one `<body>` element in a document.
 
 ## See also
 

--- a/content/html/reference/elements/br/docs.md
+++ b/content/html/reference/elements/br/docs.md
@@ -34,8 +34,6 @@ elements and use the [CSS](/en-US/docs/CSS)
 [`margin`](/en-US/docs/Web/CSS/margin)
 property to control their size.
 
-## Usage notes
-
 If multiple `<base>` elements are specified, only the first `href` and
 first `target` value are used; all others are ignored.
 

--- a/content/html/reference/elements/button/docs.md
+++ b/content/html/reference/elements/button/docs.md
@@ -37,8 +37,6 @@ that of the host platform the [user agent](/en-US/docs/Glossary/user_agent)
 is running on, but you can change the appearance of the button using
 [CSS](/en-US/docs/Web/CSS).
 
-## Usage notes
-
 `<button>` elements are much easier to style than
 [`<input>`](/en-US/docs/Web/HTML/Element/input)
 elements. You can add inner HTML content (think `<em>`, `<strong>` or

--- a/content/html/reference/elements/canvas/docs.md
+++ b/content/html/reference/elements/canvas/docs.md
@@ -22,7 +22,7 @@ Use the **HTML `<canvas>` element** with either the [canvas scripting
 API](/en-US/docs/Web/API/Canvas_API) or the [WebGL
 API](/en-US/docs/Web/API/WebGL_API) to draw graphics and animations.
 
-## Usage notes
+## Overview
 
 ### Alternative content
 

--- a/content/html/reference/elements/caption/docs.md
+++ b/content/html/reference/elements/caption/docs.md
@@ -21,7 +21,7 @@ The **HTML Table Caption element** (**`<caption>`**) specifies the
 caption (or title) of a table, and if used is *always* the first child
 of a [`<table>`](/en-US/docs/Web/HTML/Element/table).
 
-## Usage notes
+## Overview
 
 When the
 [`<table>`](/en-US/docs/Web/HTML/Element/table)

--- a/content/html/reference/elements/cite/docs.md
+++ b/content/html/reference/elements/cite/docs.md
@@ -23,7 +23,7 @@ author or the URL of that work. The reference may be in an
 abbreviated form according to context-appropriate conventions related to
 citation metadata.
 
-## Usage notes
+## Overview
 
 In the context of the `<cite>` element, a creative work that might be
 cited could be, for example, one of the following:

--- a/content/html/reference/elements/code/docs.md
+++ b/content/html/reference/elements/code/docs.md
@@ -22,7 +22,7 @@ intended to indicate that the text is a short fragment of computer
 code. By default, the content text is displayed using the
 [user agent's](/en-US/docs/Glossary/user_agent) default monospace font.
 
-## Usage notes
+## Overview
 
 To represent multiple lines of code, wrap the `<code>` element within a
 [`<pre>`](/en-US/docs/Web/HTML/Element/pre)

--- a/content/html/reference/elements/data/docs.md
+++ b/content/html/reference/elements/data/docs.md
@@ -19,9 +19,12 @@ recipe: html-element
 ## Short description
 
 The **HTML `<data>` element** links a given content with a
-machine-readable translation. If the content is time- or date-related,
-the [`<time>`](/en-US/docs/Web/HTML/Element/time)
-element must be used.
+machine-readable translation.
+
+## Overview
+
+If the content is time- or date-related, the
+[`<time>`](/en-US/docs/Web/HTML/Element/time) element must be used.
 
 ## See also
 

--- a/content/html/reference/elements/del/docs.md
+++ b/content/html/reference/elements/del/docs.md
@@ -23,7 +23,7 @@ deleted from a document.
 
 ## Overview
 
-This can be used when rendering change tracking or source code diffs, for
+`<del>` can be used when rendering change tracking or source code diffs, for
 example. The [`<ins>`](/en-US/docs/Web/HTML/Element/ins) element can be used for
 the opposite purpose: to indicate text that has been added to the document.
 

--- a/content/html/reference/elements/del/docs.md
+++ b/content/html/reference/elements/del/docs.md
@@ -19,11 +19,13 @@ recipe: html-element
 ## Short description
 
 The **HTML `<del>` element** represents a range of text that has been
-deleted from a document. This can be used when rendering
-change tracking or source code diffs, for example. The
-[`<ins>`](/en-US/docs/Web/HTML/Element/ins)
-element can be used for the opposite purpose: to indicate text that has
-been added to the document.
+deleted from a document.
+
+## Overview
+
+This can be used when rendering change tracking or source code diffs, for
+example. The [`<ins>`](/en-US/docs/Web/HTML/Element/ins) element can be used for
+the opposite purpose: to indicate text that has been added to the document.
 
 ## Accessibility concerns
 The presence of the `del` element is not announced by most screen

--- a/content/html/reference/elements/del/docs.md
+++ b/content/html/reference/elements/del/docs.md
@@ -23,7 +23,7 @@ deleted from a document.
 
 ## Overview
 
-`<del>` can be used when rendering change tracking or source code diffs, for
+The `<del>` element can be used when rendering change tracking or source code diffs, for
 example. The [`<ins>`](/en-US/docs/Web/HTML/Element/ins) element can be used for
 the opposite purpose: to indicate text that has been added to the document.
 

--- a/content/html/reference/elements/dfn/docs.md
+++ b/content/html/reference/elements/dfn/docs.md
@@ -30,7 +30,7 @@ pairing, or the
 element which is the nearest ancestor of the `<dfn>` is considered to be
 the definition of the term.
 
-## Usage notes
+## Overview
 
 - The `<dfn>` element marks the term being defined; the definition of
   the term should be given by the surrounding

--- a/content/html/reference/elements/dialog/docs.md
+++ b/content/html/reference/elements/dialog/docs.md
@@ -21,7 +21,7 @@ recipe: html-element
 The **HTML `<dialog>` element** represents a dialog box or other
 interactive component, such as an inspector or window.
 
-## Usage notes
+## Overview
 
 - `<form>` elements can be integrated within a dialog by specifying
   them with the attribute `method="dialog"`. When such a form is

--- a/content/html/reference/elements/div/docs.md
+++ b/content/html/reference/elements/div/docs.md
@@ -29,8 +29,6 @@ easily styled using the `class` or `id` attributes, marking a section of
 a document as being written in a different language (using the `lang`
 attribute), and so on.
 
-## Usage notes
-
 - The `<div>` element should be used only when no other semantic
   element (such as
   [`<article>`](/en-US/docs/Web/HTML/Element/article)

--- a/content/html/reference/elements/dl/docs.md
+++ b/content/html/reference/elements/dl/docs.md
@@ -31,7 +31,7 @@ element) and descriptions (provided by
 elements). Common uses for this element are to implement a glossary or
 to display metadata (a list of key-value pairs).
 
-## Usage notes
+## Overview
 
 Do not use this element (or
 [`<ul>`](/en-US/docs/Web/HTML/Element/ul)

--- a/content/html/reference/elements/em/docs.md
+++ b/content/html/reference/elements/em/docs.md
@@ -21,7 +21,7 @@ The **HTML `<em>` element** marks text that has stress emphasis. The
 `<em>` element can be nested, with each level of nesting indicating a
 greater degree of emphasis.
 
-## Usage notes
+## Overview
 
 The `<em>` element is for words that have a stressed emphasis compared
 to surrounding text, which is often limited to a word or words of a

--- a/content/html/reference/elements/embed/docs.md
+++ b/content/html/reference/elements/embed/docs.md
@@ -38,8 +38,6 @@ support for browser plug-ins, so relying upon `<embed>` is generally not
 wise if you want your site to be operable on the average user\'s
 browser.
 
-## Usage notes
-
 You can use the
 [`object-position`](/en-US/docs/Web/CSS/object-position)
 property to adjust the positioning of the embedded object within the

--- a/content/html/reference/elements/figure/docs.md
+++ b/content/html/reference/elements/figure/docs.md
@@ -27,7 +27,7 @@ frequently with a caption
 ([`<figcaption>`](/en-US/docs/Web/HTML/Element/figcaption)),
 and is typically referenced as a single unit.
 
-## Usage notes
+## Overview
 
 - Usually a `<figure>` is an image, illustration, diagram, code
   snippet, etc., that is referenced in the main flow of a document,

--- a/content/html/reference/elements/footer/docs.md
+++ b/content/html/reference/elements/footer/docs.md
@@ -25,7 +25,7 @@ or [sectioning root](/en-US/docs/Web/Guide/HTML/Sections_and_Outlines_of_an_HTML
 element. A footer typically contains information about the author of the
 section, copyright data or links to related documents.
 
-## Usage notes
+## Overview
 
 - Enclose information about the author in an
   [`<address>`](/en-US/docs/Web/HTML/Element/address)

--- a/content/html/reference/elements/h1-h6/docs.md
+++ b/content/html/reference/elements/h1-h6/docs.md
@@ -24,7 +24,7 @@ The **HTML `<h1>`--`<h6>` elements** represent six levels of section
 headings. `<h1>` is the highest section level and `<h6>` is the
 lowest.
 
-## Usage notes
+## Overview
 
 - Heading information may be used by user agents, for example, to
   construct a table of contents for a document automatically.

--- a/content/html/reference/elements/head/docs.md
+++ b/content/html/reference/elements/head/docs.md
@@ -20,7 +20,7 @@ The **HTML `<head>` element** provides general information (metadata)
 about the document, including its title and links to its scripts and
 style sheets.
 
-## Usage notes
+## Overview
 Modern, HTML5-compliant browsers automatically construct a `<head>`
 element if the tags are omitted in the markup. [This behavior cannot be
 guaranteed in ancient browsers](https://www.stevesouders.com/blog/2010/05/12/autohead-my-first-browserscope-user-test/)

--- a/content/html/reference/elements/header/docs.md
+++ b/content/html/reference/elements/header/docs.md
@@ -25,7 +25,7 @@ typically a group of introductory or navigational aids. It may contain
 some heading elements but also a logo, a search form, an author name,
 and other elements.
 
-## Usage notes
+## Overview
 
 The `<header>` element is not sectioning content and therefore does not
 introduce a new section in the

--- a/content/html/reference/elements/i/docs.md
+++ b/content/html/reference/elements/i/docs.md
@@ -22,7 +22,7 @@ from the normal text for some reason. Some examples include technical
 terms, foreign language phrases, or fictional character thoughts. It is
 typically displayed in italic type.
 
-## Usage notes
+## Overview
 
 - Use the `<i>` element for text that is set off from the normal prose
   for readability reasons. This would be a range of text with

--- a/content/html/reference/elements/kbd/docs.md
+++ b/content/html/reference/elements/kbd/docs.md
@@ -36,8 +36,6 @@ standard.
 (Sample Output) element to represent various forms of input or input
 based on visual cues.
 
-## Usage notes
-
 Other elements can be used in tandem with `<kbd>` to represent more
 specific scenarios:
 

--- a/content/html/reference/elements/label/docs.md
+++ b/content/html/reference/elements/label/docs.md
@@ -52,8 +52,6 @@ association is implicit:
 </label>
 ```
 
-## Usage notes
-
 - The form control that the label is labeling is called the *labeled
   control* of the label element. One input can be associated with
   multiple labels.

--- a/content/html/reference/elements/li/docs.md
+++ b/content/html/reference/elements/li/docs.md
@@ -36,6 +36,9 @@ an unordered list
 ([`<ul>`](/en-US/docs/Web/HTML/Element/ul)),
 or a menu
 ([`<menu>`](/en-US/docs/Web/HTML/Element/menu)).
+
+## Overview
+
 In menus and unordered lists, list items are usually displayed using
 bullet points. In ordered lists, they are usually displayed with an
 ascending counter on the left, such as a number or letter.

--- a/content/html/reference/elements/video/docs.md
+++ b/content/html/reference/elements/video/docs.md
@@ -74,8 +74,6 @@ A good general source of information on using HTML `<video>` is the
 content](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 beginner's tutorial.
 
-## Usage notes
-
 ### Styling with CSS
 
 The `<video>` element is a replaced element — its `display`


### PR DESCRIPTION
I'm not positive if this is what you were looking for with #89, but figured i would give it a shot. I saw in #55 @wbamberg mentioned rolling the usage notes into the overview. For the elements that had usage notes but no overview, i just renamed the usage notes section to overview. Also you'll notice for a few elements that didn't have overview at all..but had a longer short description i snagged some of that content to make an overview. If anything needs adjusted here just let me know.