### PR TITLE
Fix #92 - related.buildRelatedContent should be memoized

### DIFF
--- a/scripts/build-json/related-content.js
+++ b/scripts/build-json/related-content.js
@@ -72,7 +72,7 @@ function buildSection(sectionSpec) {
 const relatedContentCache = {};
 function buildRelatedContent(specName) {
   const cached = relatedContentCache[specName];
-  if (cached) {
+  if (cached !== undefined) {
     return cached;
   }
   const spec = yaml.safeLoad(fs.readFileSync(path.join(process.cwd(), specName), 'utf8'));

--- a/scripts/build-json/related-content.js
+++ b/scripts/build-json/related-content.js
@@ -69,9 +69,16 @@ function buildSection(sectionSpec) {
  * Build a single related content object given its YAML file.
  * At the top level a related content object is an array of sections.
  */
+const relatedContentCache = {};
 function buildRelatedContent(specName) {
+  const cached = relatedContentCache[specName];
+  if (cached) {
+    return cached;
+  }
   const spec = yaml.safeLoad(fs.readFileSync(path.join(process.cwd(), specName), 'utf8'));
-  return spec.map(buildSection);
+  const result = spec.map(buildSection);
+  relatedContentCache[specName] = result;
+  return result;
 }
 
 module.exports = {


### PR DESCRIPTION
Before this patch, `npm run build-json html` called the `buildRelatedContent` function 50 times with the same argument. This does `readFileSync` each time, which is expensive. This patch caches the result of `buildRelatedContent` depending on the argument, and returns the cache if it's been set.