### PR TITLE
only travis build against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js: stable
 cache: npm
+branches:
+  only:
+    - master
 
 script:
   - npm run test


### PR DESCRIPTION
Now that we have dependabot making PRs, because of the way it works, they add the PR branches here into *this* repo. Not dependabot's own fork. 

What happens then is that Travis will build twice. Once for the PR ("Will this work if this PR is merged into master?") and once for the branch itself ("Will it work if this is the master branch?"). 
It's a wasted effort. 

We only need the PR build. 

<img width="897" alt="Screen Shot 2019-08-16 at 9 33 57 AM" src="https://user-images.githubusercontent.com/26739/63171276-38b2ee80-c009-11e9-8720-7467d7eefd8c.png">
