### PR TITLE
Use the recipe to drive the renderer

### DIFF
--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -9,9 +9,6 @@ body:
 - prose.accessibility_concerns?
 - prose.*
 - meta.examples
-- meta.info_box:
-    - meta.api
-    - meta.permitted_aria_roles
-    - meta.tag_omission
+- meta.info_box
 - meta.browser_compatibility
 - prose.see_also

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -55,7 +55,7 @@ async function processProseIngredient(ingredientName, proseSections) {
             return matches[0];
         }
     } else {
-        const additional = proseSections.filter(section => !section.value.id);
+        const value = proseSections.filter(section => !section.value.id);
         return {
           type: 'additional_prose',
           value: additional

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -40,6 +40,7 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
             return await examples.package(examplesPaths);
         case 'info_box':
             // TODO: implement packaging for info boxes
+            // See: https://github.com/mdn/stumptown-content/issues/106
             return 'info_box-value';
         default:
             console.error(`Error: Unrecognized ingredient: ${ingredient}`);

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -22,29 +22,75 @@ function writeToFile(json, elementPath) {
   fs.writeFileSync(dest, `${JSON.stringify(json, null, 2)}`);
 };
 
+async function processMetaIngredient(elementPath, ingredientName, data) {
+    switch (ingredientName) {
+        case 'interactive_example':
+            return data.interactive_example;
+        case 'browser_compatibility':
+            return bcd.package(data.browser_compatibility);
+        case 'attributes':
+            if (data.attributes.element_specific) {
+                const attributesPath = path.join(elementPath, data.attributes.element_specific);
+                return await attributes.package(attributesPath);
+            } else {
+                return [];
+            }
+        case 'examples':
+            const examplesPaths = data.examples.map(relativePath => path.join(elementPath, relativePath));
+            return await examples.package(examplesPaths);
+        case 'info_box':
+            // TODO: implement packaging for info boxes
+            return 'info_box-value';
+        default:
+            console.error(`Error: Unrecognized ingredient: ${ingredient}`);
+            return null;
+    }
+}
+
+async function processProseIngredient(ingredientName, proseSections) {
+    if (ingredientName !== '*') {
+        const matches = proseSections.filter(section => section.value.id === ingredientName);
+        if (matches.length > 0) {
+            return matches[0];
+        }
+    } else {
+        const additional = proseSections.filter(section => !section.value.id);
+        return {
+          type: 'additional_prose',
+          value: additional
+        };
+    }
+}
+
 async function buildFromRecipe(elementPath, data, content) {
     const item = {};
+    item.title = data.title;
+    item.mdn_url = data.mdn_url;
 
-    // load the recipe to get related_content
     const recipePath = path.join(process.cwd(), './recipes', `${data.recipe}.yaml`);
     const recipe = yaml.safeLoad(fs.readFileSync(recipePath, 'utf8'));
     item.related_content = related.buildRelatedContent(recipe.related_content);
 
-    item.title = data.title;
-    item.mdn_url = data.mdn_url;
-    item.interactive_example_url = data.interactive_example;
-    item.browser_compatibility = bcd.package(data.browser_compatibility);
-  
-    if (data.attributes.element_specific) {
-        const attributesPath = path.join(elementPath, data.attributes.element_specific);
-        item.attributes = await attributes.package(attributesPath);
-    } else {
-        item.attributes = [];
-    }
-
-    const examplesPaths = data.examples.map(relativePath => path.join(elementPath, relativePath));
-    item.examples = await examples.package(examplesPaths);
-    item.prose = await prose.package(content);
+    // for each ingredient in the recipe, process the item's ingredient
+    const proseSections = await prose.package(content);
+    item.body = await Promise.all(recipe.body.map(async ingredient => {
+        const [ingredientType, ingredientName] = ingredient.replace(/\?$/, '').split('.');
+        if (ingredientType === 'meta') {
+            const value = await processMetaIngredient(elementPath, ingredientName, data);
+            if (value) {
+                return {
+                  type: ingredientName,
+                  value: value
+                };
+            }
+        } else if (ingredientType === 'prose') {
+            return await processProseIngredient(ingredientName, proseSections);
+        } else {
+            throw (`Error: Unrecognized ingredient type: ${ingredientType}`);
+        }
+    }));
+    // filter out missing ingredients
+    item.body = item.body.filter(x => !!x);
 
     const contributorsPath = path.join(elementPath, 'contributors.md');
     item.contributors = await contributors.package(contributorsPath);

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -43,8 +43,7 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
             // See: https://github.com/mdn/stumptown-content/issues/106
             return 'info_box-value';
         default:
-            console.error(`Error: Unrecognized ingredient: ${ingredient}`);
-            return null;
+            throw new Error(`Unrecognized ingredient: ${ingredient}`);
     }
 }
 
@@ -53,6 +52,8 @@ async function processProseIngredient(ingredientName, proseSections) {
         const matches = proseSections.filter(section => section.value.id === ingredientName);
         if (matches.length) {
             return matches[0];
+        } else {
+            return null;
         }
     } else {
         const value = proseSections.filter(section => !section.value.id);
@@ -87,7 +88,7 @@ async function buildFromRecipe(elementPath, data, content) {
         } else if (ingredientType === 'prose') {
             return await processProseIngredient(ingredientName, proseSections);
         } else {
-            throw (`Error: Unrecognized ingredient type: ${ingredientType}`);
+            throw new Error(`Unrecognized ingredient type: ${ingredientType} in ${elementPath}`);
         }
     }));
     // filter out missing ingredients

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -51,7 +51,7 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
 async function processProseIngredient(ingredientName, proseSections) {
     if (ingredientName !== '*') {
         const matches = proseSections.filter(section => section.value.id === ingredientName);
-        if (matches.length > 0) {
+        if (matches.length) {
             return matches[0];
         }
     } else {

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -58,7 +58,7 @@ async function processProseIngredient(ingredientName, proseSections) {
         const value = proseSections.filter(section => !section.value.id);
         return {
           type: 'additional_prose',
-          value: additional
+          value
         };
     }
 }

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -33,35 +33,37 @@ function extractFromSiblings(node, terminatorTag, contentType) {
     return content;
 }
 
-function getSection(node, sections) {
+function getSectionValue(node, sections) {
     const sectionName = node.textContent.trim();
     const sectionContent = extractFromSiblings(node, 'H2', 'html');
 
     if (namedSections.includes(sectionName)) {
-        const sectionSlug = sectionNameToSlug(sectionName);
-        sections[sectionSlug] = {
+        const sectionId = sectionNameToSlug(sectionName);
+        return {
             title: sectionName,
+            id: sectionId,
             content: sectionContent
-        }
+        };
     } else {
-        const additionalSection = {
+        return {
             title: sectionName,
             content: sectionContent
         };
-      sections['additional_sections'].push(additionalSection);
     }
 }
 
 async function package(proseMD) {
-    const proseHTML = await markdown.markdownToHTML(proseMD)
+    const proseHTML = await markdown.markdownToHTML(proseMD);
     const dom = JSDOM.fragment(proseHTML);
-    const sections = {
-        'additional_sections': []
-    };
+    const sections = [];
     let node = dom.firstChild;
     while (node) {
         if (node.nodeName === 'H2') {
-            getSection(node, sections);
+            const sectionValue = getSectionValue(node, sections);
+            sections.push({
+                type: 'prose',
+                value: sectionValue
+            });
         }
         node = node.nextSibling;
     }


### PR DESCRIPTION
This PR is an attempt to implement something like https://github.com/mdn/stumptown-content/issues/68#issuecomment-516347924.

It changes the build-json stuff to emit something like:

```
{
  "title": "<bdi>: The Bidirectional Isolate element",
  "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdi",
  "related_content": [...],
  "body": [
    {
      "type": "prose",
      "value": {
        "title": "Short description",
        "id": "short_description",
        "content": "..."
      }
    },
    {
      "type": "interactive_example",
      "value": "https://interactive-examples.mdn.mozilla.net/pages/tabbed/bdi.html"
    },
    {
      "type": "prose",
      "value": {
        "title": "Overview",
        "id": "overview",
        "content": "..."
      }
    },
    {
      "type": "attributes",
      "value": [...]
    },
    {
      "type": "additional_prose",
      "value": [
        {
          "type": "prose",
          "value": {
            "title": "Some custom section",
            "content": "..."
          }
        }
      ]
    },
    {
      "type": "examples",
      "value": [...]
    },
    {
      "type": "info_box",
      "value": "info_box-value"
    },
    {
      "type": "browser_compatibility",
      "value": {...}
    },
    {
      "type": "prose",
      "value": {
        "title": "See also",
        "id": "see_also",
        "content": "..."
      }
    }
  ],
  "contributors": "..."
}
```

That is, is has `title`, `mdn-url`, then `related_content`. Then `body` which is an array of the bits of the page.

Each element in the `body` array is an object where:
* `type` is the type of thing, either `prose` for a simple prose section or an identifier like `interactive_example`
* `value` is the value of the thing and its syntax is dependent on the value of `type`.

The elements in `body` are listed in the order we expect them to be in the page (which is also the order they're listed in the recipe.

Features of this are that build-json is pretty generic: it has to add code when we invent a new atomic piece of a page, but not just for a new recipe (so for example this should be able to handle the proposed [input element type](https://github.com/mdn/stumptown-content/issues/102) without any changes). And then the renderer is generic: again it has to know how to render each atomic piece, but to render any page it just has to walk through the array rendering each piece in order.

Another feature of course is that the JSON output is much closer to the MDN page than the current one in, and we'd have to decide, eventually, whether that's a direction we want to go in.

This PR also comes with the change proposed for `info_box` (https://github.com/mdn/stumptown-content/issues/106). It would be possible to keep the original syntax, although it would make the processing more complicated. But I don't think keeping the old syntax would be the right thing to do. I'm still not sure what we should do with "info boxes" - most reference pages have them in one form or another and it would be good to invent a generic syntax for them.