### PR TITLE
make build-page-json more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "pretty": "prettier --check scripts/**/*.js",
         "prettify": "prettier --write scripts/**/*.js",
         "lint-md": "remark -q -f content",
-        "lint-js": "eslint .",
+        "lint-js": "eslint scripts/**/*.js",
         "build-json": "node scripts/build-json/build-json.js",
         "scrape-mdn": "node scripts/scraper/scrape-mdn.js",
         "spell-md": "mdspell -a -n -r -x --en-us 'content/**/!(*contributors).md'",

--- a/scripts/build-json/build-json.js
+++ b/scripts/build-json/build-json.js
@@ -2,12 +2,13 @@ const fs = require('fs');
 const path = require('path');
 
 const buildPage = require('./build-page-json');
+const { ROOT } = require('./constants');
 
 function walk(directory, filepaths) {
     const files = fs.readdirSync(directory);
     for (let filename of files) {
         const filepath = path.join(directory, filename);
-        if (path.extname(filename) === '.md') {
+        if (path.extname(filename) === '.md' && !/readme.md/i.test(filename)) {
             filepaths.push(path.join(directory, filename));
             continue;
         }
@@ -17,26 +18,37 @@ function walk(directory, filepaths) {
     }
 }
 
-function collectItems(directory, searchPaths) {
+function findItems(directory, searchPaths) {
     let filepaths = [];
     walk(directory, filepaths);
-    filepaths = filepaths.map( 
-        filepath => filepath.slice(path.join(process.cwd(), './content/').length) 
-    ).filter(filepath => !searchPaths.length || searchPaths.some(searchPath => filepath.includes(searchPath)))
-    return filepaths;
+    return filepaths.filter(
+        filePath => !searchPaths.length || searchPaths.some(searchPath => filePath.includes(searchPath)));
 }
 
 function buildJSON(searchPaths) {
     let errors = 0;
-    const items = collectItems(path.resolve(process.cwd(), './content'), searchPaths);
+    const items = findItems(path.resolve(ROOT, 'content'), searchPaths);
     if (!items.length && searchPaths.length) {
         console.error("No elements found");
         errors++;
     }
-    for (let item of items) {
-        const parsed = path.parse(item);
-        errors += buildPage.buildPageJSON(parsed.dir, parsed.base);
-    }
+    
+    // XXX Would it be "faster" to Promise.all() spawn these async tasks?!
+    items.forEach(async item => {
+        let built
+        try {
+            built = await buildPage.buildPageJSON(item);
+            const { docsPath, destPath } = built;
+            if (destPath !== null) {
+                console.log(`Packaged ${docsPath} to ${destPath}`);
+            }
+        } catch (error) {
+            console.warn(`Failed to build page JSON from ${item}`);
+            console.error(error);
+            errors++;
+        }
+        
+    })
     return errors;
 }
 

--- a/scripts/build-json/build-json.js
+++ b/scripts/build-json/build-json.js
@@ -33,7 +33,6 @@ function buildJSON(searchPaths) {
         errors++;
     }
     
-    // XXX Would it be "faster" to Promise.all() spawn these async tasks?!
     items.forEach(async item => {
         let built
         try {

--- a/scripts/build-json/build-json.js
+++ b/scripts/build-json/build-json.js
@@ -8,7 +8,7 @@ function walk(directory, filepaths) {
     const files = fs.readdirSync(directory);
     for (let filename of files) {
         const filepath = path.join(directory, filename);
-        if (path.extname(filename) === '.md' && !/readme.md/i.test(filename)) {
+        if (path.extname(filename) === '.md') {
             filepaths.push(path.join(directory, filename));
             continue;
         }
@@ -32,7 +32,7 @@ function buildJSON(searchPaths) {
         console.error("No elements found");
         errors++;
     }
-    
+
     items.forEach(async item => {
         let built
         try {
@@ -46,7 +46,7 @@ function buildJSON(searchPaths) {
             console.error(error);
             errors++;
         }
-        
+
     })
     return errors;
 }

--- a/scripts/build-json/build-json.js
+++ b/scripts/build-json/build-json.js
@@ -28,7 +28,7 @@ function buildJSON(searchPaths) {
         errors++;
     }
 
-    const cwd = process.cwd() + '/';
+    const cwd = process.cwd() + path.sep;
     function printPath(p) {
         return p.replace(cwd, '');
     }

--- a/scripts/build-json/build-json.js
+++ b/scripts/build-json/build-json.js
@@ -10,7 +10,7 @@ function findItems(directory, searchPaths, filepaths = []) {
     for (let filename of files) {
         const filepath = path.join(directory, filename);
         if (path.extname(filename) === '.md') {
-            if (!searchPaths.length || searchPaths.some(searchPath => filePath.includes(searchPath))) {
+            if (!searchPaths.length || searchPaths.some(s => filepath.includes(s))) {
                 filepaths.push(filepath);
             }
         } else if (fs.statSync(filepath).isDirectory()) {

--- a/scripts/build-json/constants.js
+++ b/scripts/build-json/constants.js
@@ -1,0 +1,9 @@
+const path = require("path");
+
+// Root of the whole stumptown-content.
+// To be used instead of process.cwd()
+const ROOT = path.join(__dirname, "..", "..");
+
+module.exports = {
+    ROOT
+};

--- a/scripts/build-json/related-content.js
+++ b/scripts/build-json/related-content.js
@@ -3,6 +3,8 @@ const path = require('path');
 const yaml = require('js-yaml');
 const matter = require('gray-matter');
 
+const { ROOT } = require('./constants');
+
 /**
  * Get a single item from front matter
  */
@@ -19,7 +21,7 @@ function itemFromFile(filePath) {
  * that is just an ordered list of pages.
  */
 function sectionFromChapterList(chapterListPath) {
-  const fullPath = path.join(process.cwd(), chapterListPath);
+  const fullPath = path.join(ROOT, chapterListPath);
   const fullDir = path.dirname(fullPath);
   const chapterList = yaml.safeLoad(fs.readFileSync(fullPath, 'utf8'));
   const chapterPaths = chapterList.chapters.map(chapter => path.join(fullDir, chapter));
@@ -34,8 +36,8 @@ function sectionFromChapterList(chapterListPath) {
  * - list all the children of this directory.
  */
 function sectionFromDirectory(directory) {
-  const fullPath = path.join(process.cwd(), directory);
-  let itemDirectories = fs.readdirSync(path.join(process.cwd(), directory));
+  const fullPath = path.join(ROOT, directory);
+  let itemDirectories = fs.readdirSync(path.join(ROOT, directory));
   itemDirectories = itemDirectories.map(itemDirectory => path.join(fullPath, itemDirectory, 'docs.md'));
   return itemDirectories.map(itemFromFile);
 }
@@ -75,7 +77,7 @@ function buildRelatedContent(specName) {
   if (cached !== undefined) {
     return cached;
   }
-  const spec = yaml.safeLoad(fs.readFileSync(path.join(process.cwd(), specName), 'utf8'));
+  const spec = yaml.safeLoad(fs.readFileSync(path.join(ROOT, specName), 'utf8'));
   const result = spec.map(buildSection);
   relatedContentCache[specName] = result;
   return result;


### PR DESCRIPTION
Hopefully, there is very little difference. You still use it like this:
```
# Build EVERYTHING in ./content/**/*.md
npm run build-json
```
or
```
# Build everything in ./content/html/guides/*.md
npm run build-json html/guides
```
or
```
# Build everything in ./content/html/reference/elements/**/*.md
npm run build-json html/reference/elements
```
or
```
# Build EVERYTHING in ./content/html/reference/elements/em/*.md
npm run build-json html/reference/elements/em/
```

The other new thing is that the console logging about what was done is unique to the cli function in `build-json.js`. Now `build-page-json.js` only returns what it built or throws errors. No return values. 

Another new thing is the output is a lot more verbose. E.g.:
```
▶ npm run build-json html/reference/elements/em

> stump@0.1.0 build-json /Users/peterbe/dev/MOZILLA/MDN/stumptown-content
> node scripts/build-json/build-json.js "html/reference/elements/em"

Packaged /Users/peterbe/dev/MOZILLA/MDN/stumptown-content/content/html/reference/elements/em/docs.md to /Users/peterbe/dev/MOZILLA/MDN/stumptown-content/packaged/html/reference/elements/em.json
Packaged /Users/peterbe/dev/MOZILLA/MDN/stumptown-content/content/html/reference/elements/embed/docs.md to /Users/peterbe/dev/MOZILLA/MDN/stumptown-content/packaged/html/reference/elements/embed.json

```
The advantage here is that all of those file references printed are full real paths that you can copy-and-paste. 

Another new difference is that beyond the `build-json` cli function, it's all full real paths. 
Why? Because it feels much better. And, more importantly, it's needed for my work on the `make watch-content` in the cli of stumptown-renderer. It imports `build-page-json.js` dynamically and it's confusing if it depends on the input being a "search term" rather than the actual file that matters. Only the `build-json` is automagical in that in converts arguments into real paths. 




