### PR TITLE
pin exact version of mdn-browser-compat-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         },
         "ansi-escapes": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
             "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
@@ -839,7 +839,7 @@
         },
         "external-editor": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
             "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
             "requires": {
                 "extend": "^3.0.0",
@@ -1325,7 +1325,7 @@
         },
         "inquirer": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+            "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
             "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
             "requires": {
                 "ansi-escapes": "^1.1.0",
@@ -1760,9 +1760,9 @@
             "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A=="
         },
         "mdn-browser-compat-data": {
-            "version": "0.0.93",
-            "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.93.tgz",
-            "integrity": "sha512-rrgjwkQOz/c9LMLMuTRslvkx0m3/BQdw8eCT4GB2vyApPClD6yxjzFJ37xzIfSLqiF0fQkFNGrW7MkzHoR8LjA==",
+            "version": "0.0.94",
+            "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.94.tgz",
+            "integrity": "sha512-O3zJqbmehz0Hn3wpk62taA0+jNF7yn6BDWqQ9Wh2bEoO9Rx1BYiTmNX565eNVbW0ixfQkY6Sp9FvY/rr79Qmyg==",
             "requires": {
                 "extend": "3.0.2"
             }
@@ -1801,7 +1801,7 @@
         },
         "minimist": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
@@ -1851,7 +1851,7 @@
         "node-fetch": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+            "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -1907,7 +1907,7 @@
         },
         "onetime": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "optionator": {
@@ -2145,7 +2145,7 @@
         "rehype-raw": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-4.0.1.tgz",
-            "integrity": "sha512-g74dPCUWeB9EBfTfGF3lGOHSnZwFwN1ssc3Je9OwQO9f8yTkkAIrMqUVxT34h8zpi4ICU051tTLBZbOrzRWpxg==",
+            "integrity": "sha1-ZeIoRp4SmiypT+R3eBMstkf7lxg=",
             "requires": {
                 "hast-util-raw": "^5.0.0"
             }
@@ -2153,7 +2153,7 @@
         "rehype-remark": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-6.0.0.tgz",
-            "integrity": "sha512-gERmKDCIwZiZqjtHDpPF+2zq/A2OrCkVoa/DcNUNtsdfbDK8UH6elnxse5ZrzNlHIOWrAGODtQG+4mO9GbGYCQ==",
+            "integrity": "sha1-+kd5JkYE4HNGFI44yk8dLh1WiUM=",
             "requires": {
                 "hast-util-to-mdast": "^5.0.0"
             }
@@ -2161,7 +2161,7 @@
         "rehype-stringify": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-6.0.0.tgz",
-            "integrity": "sha512-grV/hhA7z9GbUJZk0ILzprSE0YY9lvTmYuvgRjXdFXrrag5gNeqXBQIuG1m4zFW6PFm0YYnJ/qgf5y6yui4VsA==",
+            "integrity": "sha1-qKVztvm/mJFpVZeKzXRsN8/YisA=",
             "requires": {
                 "hast-util-to-html": "^6.0.0",
                 "xtend": "^4.0.1"
@@ -2562,7 +2562,7 @@
         "remark-preset-lint-recommended": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-3.0.3.tgz",
-            "integrity": "sha512-5sQ34j1Irlsj6Tt4WWRylZ7UU+1jD5es/LfDZBZp/LXDwC4ldGqKpMmCCR6Z00x1jYM1phmS4M+eGqTdah0qkQ==",
+            "integrity": "sha1-EyKvDkmAEngFf48nXtG27WAyi0A=",
             "requires": {
                 "remark-lint": "^6.0.0",
                 "remark-lint-final-newline": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "js-yaml": "3.13.1",
         "jsdom": "^15.1.1",
         "markdown-spellcheck": "1.3.1",
-        "mdn-browser-compat-data": "0.x",
+        "mdn-browser-compat-data": "0.0.94",
         "node-fetch": "2.6.0",
         "rehype-parse": "6.0.1",
         "rehype-raw": "4.0.1",


### PR DESCRIPTION
I know why it was `0.x` before. It's a relic from how kuma and kumascript works. It relies on this version marker so that every time you build a new Docker image of KumaScript it downloads the latest version. 

As of this change, as soon as a new version comes out, Dependabot will prepare a PR here and we immediately find out if that's going to work. Both here and with stumptown-renderer. 

My hope is that, within some limits, we might ship a whole new production site as soon as something merges to `master` here in this repo. That means, that minutes after BCD makes a new release, Dependabot makes a PR, and seconds/minutes after that's merged it would go out to developer.mozilla.org. 

And what's neat too is that we'd still be able to control that. Suppose that the format in BCD changes, we won't get nasty surprises because CI would hopefully break or we'd manually hold back the Dependabot PR. 