### PR TITLE
Adjust built JSON for guide pages

### DIFF
--- a/scripts/build-json/build-guide-page-json.js
+++ b/scripts/build-json/build-guide-page-json.js
@@ -10,7 +10,7 @@ async function processDirective(elementPath, directive) {
         case 'embed-example':
             return {
                 type: 'example',
-                content: await examples.packageExample(path.join(elementPath, directiveComponents[1]))
+                value: await examples.packageExample(path.join(elementPath, directiveComponents[1]))
             }
         default:
             throw ('Unsupported guide directive');
@@ -20,7 +20,9 @@ async function processDirective(elementPath, directive) {
 async function processProse(elementPath, proseMD) {
     return {
         type: 'prose',
-        content: await markdown.markdownToHTML(proseMD)
+        value: {
+          content: await markdown.markdownToHTML(proseMD)
+        }
     }
 }
 
@@ -43,7 +45,7 @@ async function buildGuidePageJSON(elementPath, data, content) {
         title: data.title,
         mdn_url: data.mdn_url,
         related_content: related.buildRelatedContent(data.related_content),
-        content: await buildGuideContentJSON(elementPath, data, content)
+        body: await buildGuideContentJSON(elementPath, data, content)
     };
 }
 


### PR DESCRIPTION
I was looking at the JSON output for guide pages and realised it wasn't consistent with the output for reference pages. This should make it closer.

In this PR guide pages get a `prose` element, but it's different from the on for reference pages because it doesn't have `title` or `id` - that's because in guide pages prose sections don't correspond to section headings. I think these should render fine using the existing [`Prose` component](https://github.com/mdn/stumptown-renderer/blob/master/client/src/document.js#L220). The logic [here](https://github.com/mdn/stumptown-renderer/blob/master/client/src/document.js#L161) could be tweaked to always use `Prose` if `title` is missing.

One difference between this and reference pages is that reference pages have `examples` which is an array of example specifications, and which are rendered with an H2 "Examples". But guide pages just contain single examples that should not get an H2 heading. So the JSON for guide pages has `example` which just contains one, and which should not get the H2. So there would need to be some changes in the renderer to handle it.

Anyway, if this gets merged I'll open a PR in the renderer to understand it, and we'll be able to render guide pages.
