### PR TITLE
Add short_title

### DIFF
--- a/content/html/reference/elements/abbr/docs.md
+++ b/content/html/reference/elements/abbr/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<abbr>: The Abbreviation element'
+short_title: <abbr>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/abbr
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/address/docs.md
+++ b/content/html/reference/elements/address/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<address>: The Contact Address element'
+short_title: <address>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/address
 tags:
     group: Content sectioning

--- a/content/html/reference/elements/article/docs.md
+++ b/content/html/reference/elements/article/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<article>: The Article Contents element'
+short_title: <article>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/article
 tags:
     group: Flow content

--- a/content/html/reference/elements/aside/docs.md
+++ b/content/html/reference/elements/aside/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<aside>: The Aside element'
+short_title: <aside>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/aside
 tags:
     group: Flow content

--- a/content/html/reference/elements/audio/docs.md
+++ b/content/html/reference/elements/audio/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<audio>: The Embed Audio element'
+short_title: <audio>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/audio
 tags:
     group: Image and multimedia

--- a/content/html/reference/elements/b/docs.md
+++ b/content/html/reference/elements/b/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<b>: The Bring Attention To element'
+short_title: <b>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/b
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/base/docs.md
+++ b/content/html/reference/elements/base/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<base>: The Document Base URL element'
+short_title: <base>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/base
 tags:
     group: Document metadata

--- a/content/html/reference/elements/bdi/docs.md
+++ b/content/html/reference/elements/bdi/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<bdi>: The Bidirectional Isolate element'
+short_title: <bdi>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/bdi
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/bdo/docs.md
+++ b/content/html/reference/elements/bdo/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<bdo>: The Bidirectional Text Override element'
+short_title: <bdo>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/bdo
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/blockquote/docs.md
+++ b/content/html/reference/elements/blockquote/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<blockquote>: The Block Quotation element'
+short_title: <blockquote>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/blockquote
 tags:
     group: Text content

--- a/content/html/reference/elements/body/docs.md
+++ b/content/html/reference/elements/body/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<body>: The Document Body element'
+short_title: <body>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/body
 tags:
     group: Sectioning root

--- a/content/html/reference/elements/br/docs.md
+++ b/content/html/reference/elements/br/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<br>: The Line Break element'
+short_title: <br>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/br
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/button/docs.md
+++ b/content/html/reference/elements/button/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<button>: The Button element'
+short_title: <button>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/button
 tags:
     group: Forms

--- a/content/html/reference/elements/canvas/docs.md
+++ b/content/html/reference/elements/canvas/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<canvas>: The Graphics Canvas element'
+short_title: <canvas>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/canvas
 tags:
     group: Scripting

--- a/content/html/reference/elements/caption/docs.md
+++ b/content/html/reference/elements/caption/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<caption>: The Table Caption element'
+short_title: <caption>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/caption
 tags:
     group: Table content

--- a/content/html/reference/elements/cite/docs.md
+++ b/content/html/reference/elements/cite/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<cite>: The Citation element'
+short_title: <cite>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/cite
 tags:
     group: Text content

--- a/content/html/reference/elements/code/docs.md
+++ b/content/html/reference/elements/code/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<code>: The Inline Code element'
+short_title: <code>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/code
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/col/docs.md
+++ b/content/html/reference/elements/col/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<col>'
+short_title: <col>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/col
 tags:
     group: Table content

--- a/content/html/reference/elements/colgroup/docs.md
+++ b/content/html/reference/elements/colgroup/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<colgroup>'
+short_title: <colgroup>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/colgroup
 tags:
     group: Table content

--- a/content/html/reference/elements/data/docs.md
+++ b/content/html/reference/elements/data/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<data>'
+short_title: <data>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/data
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/datalist/docs.md
+++ b/content/html/reference/elements/datalist/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<datalist>'
+short_title: <datalist>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/datalist
 tags:
     group: Forms

--- a/content/html/reference/elements/dd/docs.md
+++ b/content/html/reference/elements/dd/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<dd>: The Description Details element'
+short_title: <dd>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dd
 tags:
     group: Text content

--- a/content/html/reference/elements/del/docs.md
+++ b/content/html/reference/elements/del/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<del>: The Deleted Text element'
+short_title: <del>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/del
 tags:
     group: Demarcating edits

--- a/content/html/reference/elements/details/docs.md
+++ b/content/html/reference/elements/details/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<details>: The Details disclosure element'
+short_title: <details>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/details
 tags:
     group: Interactive elements

--- a/content/html/reference/elements/dfn/docs.md
+++ b/content/html/reference/elements/dfn/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<dfn>: The Definition element'
+short_title: <dfn>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dfn
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/dialog/docs.md
+++ b/content/html/reference/elements/dialog/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<dialog>: The Dialog element'
+short_title: <dialog>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dialog
 tags:
     group: Interactive elements

--- a/content/html/reference/elements/div/docs.md
+++ b/content/html/reference/elements/div/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<div>: The Content Division element'
+short_title: <div>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/div
 tags:
     group: Text content

--- a/content/html/reference/elements/dl/docs.md
+++ b/content/html/reference/elements/dl/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<dl>: The Description List element'
+short_title: <dl>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dl
 tags:
     group: Text content

--- a/content/html/reference/elements/dt/docs.md
+++ b/content/html/reference/elements/dt/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<dt>: The Description Term element'
+short_title: <dt>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dt
 tags:
     group: Text content

--- a/content/html/reference/elements/em/docs.md
+++ b/content/html/reference/elements/em/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<em>: The Emphasis element'
+short_title: <em>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/em
 tags:
     group: Inline text semantics

--- a/content/html/reference/elements/embed/docs.md
+++ b/content/html/reference/elements/embed/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<embed>: The Embed External Content element'
+short_title: <embed>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/embed
 tags:
     group: Embedded content

--- a/content/html/reference/elements/fieldset/docs.md
+++ b/content/html/reference/elements/fieldset/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<fieldset>: The Field Set element'
+short_title: <fieldset>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/fieldset
 tags:
     group: Forms

--- a/content/html/reference/elements/figcaption/docs.md
+++ b/content/html/reference/elements/figcaption/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<figcaption>'
+short_title: <figcaption>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/figcaption
 tags:
     group: Text content

--- a/content/html/reference/elements/figure/docs.md
+++ b/content/html/reference/elements/figure/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<figure>'
+short_title: <figure>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/figure
 tags:
     group: Text content

--- a/content/html/reference/elements/h1-h6/docs.md
+++ b/content/html/reference/elements/h1-h6/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<h1>–<h6>: The HTML Section Heading elements'
+short_title: <h1>-<h6>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements
 tags:
     group: Content sectioning

--- a/content/html/reference/elements/head/docs.md
+++ b/content/html/reference/elements/head/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<head>: The Document Metadata (Header) element'
+short_title: <head>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/head
 tags:
     group: Document metadata

--- a/content/html/reference/elements/hr/docs.md
+++ b/content/html/reference/elements/hr/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<hr>: The Thematic Break (Horizontal Rule) element'
+short_title: <hr>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/hr
 tags:
     group: Text content

--- a/content/html/reference/elements/html/docs.md
+++ b/content/html/reference/elements/html/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<html>: The HTML Document / Root element'
+short_title: <html>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/html
 tags:
     group: Main root

--- a/content/html/reference/elements/iframe/docs.md
+++ b/content/html/reference/elements/iframe/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<iframe>: The Inline Frame element'
+short_title: <iframe>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/iframe
 tags:
     group: Embedded content

--- a/content/html/reference/elements/kbd/docs.md
+++ b/content/html/reference/elements/kbd/docs.md
@@ -1,5 +1,6 @@
 ---
 title: '<kbd>: The Keyboard Input element'
+short_title: <kbd>
 mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/kbd
 tags:
     group: Inline text semantics

--- a/scripts/build-json/build-link-lists.js
+++ b/scripts/build-json/build-link-lists.js
@@ -20,6 +20,7 @@ async function itemFromFile(includeShortDescriptions, filePath) {
   }
   return {
       title: data.title,
+      short_title: data.short_title || null,
       mdn_url: data.mdn_url,
       short_description: shortDescriptions.length && shortDescriptions[0].value.content || null
     };


### PR DESCRIPTION
Fix for https://github.com/mdn/stumptown-content/issues/76.

This adds a new optional item in front matter, `short_title`. If present it's added to the `related_content` entry for the item. I've included both this and `title`, since choosing which to use feels like a renderer choice.

Questions:

* should we do this? I think that if we want to have long titles for pages, like "<abbr>: The Abbreviation element" then yes, we should have a short alternative for places like the sidebar. This isn't just about the available space, it's also about context: if this link appears in a list headed "HTML elements", say, then repeating "element" for every item looks silly. But for the title of a page it may be better to supply extra context.

* should it be in the recipe? I've not included it in the recipe, since we don't include `title`. I think if we include either we should include both.
