### PR TITLE
Fix guide sidebar

### DIFF
--- a/scripts/build-json/build-guide-page-json.js
+++ b/scripts/build-json/build-guide-page-json.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const markdown = require('./markdown-converter');
 const examples = require('./compose-examples');
-const related = require('./related-content');
 
 async function processDirective(elementPath, directive) {
     const directiveComponents = directive.split(':');
@@ -40,15 +39,6 @@ async function buildGuideContentJSON(elementPath, data, content) {
     return result;
 }
 
-async function buildGuidePageJSON(elementPath, data, content) {
-    return {
-        title: data.title,
-        mdn_url: data.mdn_url,
-        related_content: await related.buildRelatedContent(data.related_content),
-        body: await buildGuideContentJSON(elementPath, data, content)
-    };
-}
-
 module.exports = {
-    buildGuidePageJSON
+    buildGuideContentJSON
 }

--- a/scripts/build-json/build-guide-page-json.js
+++ b/scripts/build-json/build-guide-page-json.js
@@ -44,7 +44,7 @@ async function buildGuidePageJSON(elementPath, data, content) {
     return {
         title: data.title,
         mdn_url: data.mdn_url,
-        related_content: related.buildRelatedContent(data.related_content),
+        related_content: await related.buildRelatedContent(data.related_content),
         body: await buildGuideContentJSON(elementPath, data, content)
     };
 }

--- a/scripts/build-json/build-landing-page-json.js
+++ b/scripts/build-json/build-landing-page-json.js
@@ -1,4 +1,3 @@
-const related = require('./related-content');
 const links = require('./build-link-lists');
 const markdown = require('./markdown-converter');
 
@@ -48,12 +47,7 @@ async function buildLandingPageJSON(elementPath, data, content) {
             value: linkList
         };
     }));
-    return {
-        title: data.title,
-        mdn_url: data.mdn_url,
-        related_content: await related.buildRelatedContent(data.related_content),
-        body: [ overview, ...linkLists]
-    };
+    return [ overview, ...linkLists];
 }
 
 module.exports = {

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -3,15 +3,11 @@ const path = require('path');
 const yaml = require('js-yaml');
 const matter = require('gray-matter');
 
-const { packageBCD } = require('./resolve-bcd');
-const { packageExamples } = require('./compose-examples');
-const { packageAttributes } = require('./compose-attributes');
-const { packageInteractiveExample } = require('./compose-interactive-example');
-const { packageProse } = require('./slice-prose');
 const { packageContributors } = require('./resolve-contributors');
 const related = require('./related-content');
-const guide = require('./build-guide-page-json');
-const landing = require('./build-landing-page-json');
+const guidePage = require('./build-guide-page-json');
+const landingPage = require('./build-landing-page-json');
+const recipePage = require('./build-recipe-page-json');
 const { ROOT } = require('./constants');
 
 
@@ -32,69 +28,6 @@ function writeToFile(json, elementPath) {
     return dest;
 }
 
-async function processMetaIngredient(elementPath, ingredientName, data) {
-    switch (ingredientName) {
-        case 'interactive_example':
-            // interactive_example is optional
-            if (!data.interactive_example) {
-                return null;
-            }
-            return packageInteractiveExample(data.interactive_example);
-        case 'browser_compatibility':
-            return packageBCD(data.browser_compatibility);
-        case 'attributes':
-            if (data.attributes.element_specific) {
-                const attributesPath = path.join(elementPath, data.attributes.element_specific);
-                return await packageAttributes(attributesPath);
-            } else {
-                return [];
-            }
-        case 'examples': {
-          const examplesPaths = data.examples.map(relativePath => path.join(elementPath, relativePath));
-          return await packageExamples(examplesPaths);
-        }
-        case 'info_box':
-            // TODO: implement packaging for info boxes
-            // See: https://github.com/mdn/stumptown-content/issues/106
-            return 'info_box-value';
-        default:
-            throw new Error(`Unrecognized ingredient: ${ingredientName}`);
-    }
-}
-
-async function buildFromRecipe(elementPath, data, content, recipe) {
-    const body = [];
-
-    const proseSections = await packageProse(content);
-
-    // for each ingredient in the recipe, process the item's ingredient
-    for (let ingredient of recipe.body) {
-        const [ingredientType, ingredientName] = ingredient.replace(/\?$/, '').split('.');
-        if (ingredientType === 'meta') {
-            // non-prose ingredients, which are specified in front matter
-            const value = await processMetaIngredient(elementPath, ingredientName, data);
-            if (value !== null) {
-                body.push({
-                  type: ingredientName,
-                  value: value
-                });
-            }
-        } else if (ingredientType === 'prose' && ingredientName === '*') {
-            // additional (unnamed) prose sections
-            const additionalProse = proseSections.filter(section => !section.value.id);
-            body.push(...additionalProse);
-        } else if (ingredientType === 'prose') {
-            // named prose sections
-            const matches = proseSections.filter(section => section.value.id === ingredientName);
-            body.push(...matches);
-        } else {
-            throw new Error(`Unrecognized ingredient type: ${ingredientType} in ${elementPath}`);
-        }
-    }
-
-    return body;
-}
-
 async function buildPageJSON(docsPath) {
     // open docs.md and parse front matter(data) from Markdown(content)
     const docsDirectory = path.dirname(docsPath);
@@ -113,28 +46,29 @@ async function buildPageJSON(docsPath) {
 
         switch (data.recipe) {
             case 'guide':
-                body = await guide.buildGuideContentJSON(docsDirectory, data, content);
+                body = await guidePage.buildGuideContentJSON(docsDirectory, data, content);
                 // Guide pages are special because they don't have their own 
                 // directory. Instead, individual .md files share a directory. 
                 // So we need to override the name of the directory to write to.
                 elementDirectory = path.join(docsDirectory, path.basename(docsPath).split('.')[0]);
                 break;
             case 'landing-page':
-                body = await landing.buildLandingPageJSON(docsDirectory, data, content);
+                body = await landingPage.buildLandingPageJSON(docsDirectory, data, content);
                 // Landing pages are special because they don't have their own
                 // directory. Instead, individual .md files share a directory.
                 // So we need to override the name of the directory to write to.
                 elementDirectory = path.join(docsDirectory, path.basename(docsPath).split('.')[0]);
                 break;
-            case 'html-element':
-                // for recipe-driven content, related_content is in the recipe
-                const recipePath = path.join(__dirname, '..', '..', 'recipes', `${data.recipe}.yaml`);
-                const recipe = yaml.safeLoad(fs.readFileSync(recipePath, 'utf8'));
-                relatedContentSpec = recipe.related_content;
-                body = await buildFromRecipe(docsDirectory, data, content, recipe);
-                // currently only reference-driven content supports contributors
-                contributors = await packageContributors(path.join(docsDirectory, 'contributors.md'))
-                break;
+            case 'html-element': {
+                    // for recipe-driven content, related_content is in the recipe
+                    const recipePath = path.join(__dirname, '..', '..', 'recipes', `${data.recipe}.yaml`);
+                    const recipe = yaml.safeLoad(fs.readFileSync(recipePath, 'utf8'));
+                    relatedContentSpec = recipe.related_content;
+                    body = await recipePage.buildRecipePageJSON(docsDirectory, data, content, recipe);
+                    // currently only reference-driven content supports contributors
+                    contributors = await packageContributors(path.join(docsDirectory, 'contributors.md'))
+                    break;
+                }
             default:
                 throw new Error(`Not a supported recipe: ${data.recipe}`);
         }

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -1,0 +1,74 @@
+const path = require('path');
+
+const { packageBCD } = require('./resolve-bcd');
+const { packageExamples } = require('./compose-examples');
+const { packageAttributes } = require('./compose-attributes');
+const { packageInteractiveExample } = require('./compose-interactive-example');
+const { packageProse } = require('./slice-prose');
+
+async function processMetaIngredient(elementPath, ingredientName, data) {
+    switch (ingredientName) {
+        case 'interactive_example':
+            // interactive_example is optional
+            if (!data.interactive_example) {
+                return null;
+            }
+            return packageInteractiveExample(data.interactive_example);
+        case 'browser_compatibility':
+            return packageBCD(data.browser_compatibility);
+        case 'attributes':
+            if (data.attributes.element_specific) {
+                const attributesPath = path.join(elementPath, data.attributes.element_specific);
+                return await packageAttributes(attributesPath);
+            } else {
+                return [];
+            }
+        case 'examples': {
+          const examplesPaths = data.examples.map(relativePath => path.join(elementPath, relativePath));
+          return await packageExamples(examplesPaths);
+        }
+        case 'info_box':
+            // TODO: implement packaging for info boxes
+            // See: https://github.com/mdn/stumptown-content/issues/106
+            return 'info_box-value';
+        default:
+            throw new Error(`Unrecognized ingredient: ${ingredientName}`);
+    }
+}
+
+async function buildRecipePageJSON(elementPath, data, content, recipe) {
+    const body = [];
+
+    const proseSections = await packageProse(content);
+
+    // for each ingredient in the recipe, process the item's ingredient
+    for (let ingredient of recipe.body) {
+        const [ingredientType, ingredientName] = ingredient.replace(/\?$/, '').split('.');
+        if (ingredientType === 'meta') {
+            // non-prose ingredients, which are specified in front matter
+            const value = await processMetaIngredient(elementPath, ingredientName, data);
+            if (value !== null) {
+                body.push({
+                  type: ingredientName,
+                  value: value
+                });
+            }
+        } else if (ingredientType === 'prose' && ingredientName === '*') {
+            // additional (unnamed) prose sections
+            const additionalProse = proseSections.filter(section => !section.value.id);
+            body.push(...additionalProse);
+        } else if (ingredientType === 'prose') {
+            // named prose sections
+            const matches = proseSections.filter(section => section.value.id === ingredientName);
+            body.push(...matches);
+        } else {
+            throw new Error(`Unrecognized ingredient type: ${ingredientType} in ${elementPath}`);
+        }
+    }
+
+    return body;
+}
+
+module.exports = {
+    buildRecipePageJSON
+}


### PR DESCRIPTION
I was trying to update stumptown-renderer for the latest stumptown-content changes when I realized there was a bug: the [code to build `related_content` for guide pages](https://github.com/mdn/stumptown-content/blob/7b860a6d6c6e7ab651c6fe13e5560cbd0d51b6da/scripts/build-json/build-guide-page-json.js#L47) is missing `await`.

Then I thought, this happened because we are making the same call to build related content three times, once for landing pages, once for guide pages, and once for all the recipe-driven pages. So I tried refactoring things a bit to reduce this duplication.

There are a couple of things I don't like about it still:

* guide and landing pages specify `related_content` directly in their front matter, while recipe pages specify it in the recipe. I think there is sense to this, if all pages that share a recipe have a similar sidebar, while guide and landing pages are generic and can be anywhere in the site, so can have any sidebar they please. But it is a bit weird.

* only recipe pages support contributors. I think we ought to rethink the way we represent contributors anyway, so I have kept it as-is for now.
