### PR TITLE
Strip title

### DIFF
--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -62,7 +62,7 @@ function addFrontMatter(title, url, md) {
 }
 
 function removeTitleAttributes(dom) {
-  const links = dom.window.document.querySelectorAll('a');
+  const links = dom.window.document.querySelectorAll('a[title]');
   for (let link of links) {
     link.removeAttribute('title');
   }

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -61,6 +61,20 @@ function addFrontMatter(title, url, md) {
   return `---\ntitle: ${title}\nmdn_url: ${fullURL}\n---\n${md}`;
 }
 
+function removeTitleAttributes(dom) {
+  const links = dom.window.document.querySelectorAll('a');
+  for (let link of links) {
+    link.removeAttribute('title');
+  }
+}
+
+function removeSidebar(dom) {
+  const sidebar = dom.window.document.querySelector('section.Quick_links');
+  if (sidebar) {
+    sidebar.parentNode.removeChild(sidebar);
+  }
+}
+
 /**
  * 1. Convert the given HTML to JSDOM
  * 2. Do any cleaning we want
@@ -68,10 +82,8 @@ function addFrontMatter(title, url, md) {
  */
 function cleanHTML(html) {
   const dom = new JSDOM(html);
-  const sidebar = dom.window.document.querySelector('section.Quick_links');
-  if (sidebar) {
-    sidebar.parentNode.removeChild(sidebar);
-  }
+  removeTitleAttributes(dom);
+  removeSidebar(dom);
   return dom.serialize();
 }
 


### PR DESCRIPTION
(This was originally https://github.com/mdn/stumptown-content/pull/145, but I gave it the wrong name, then when I tried to rename it, GitHub closed the PR. So here it is again.)

Links in MDN documents, in particular those generated using one of the xref macros, include a `title` attribute containing the document summary, which gets converted into Markdown like this:

```
[`<input>`](/en-US/docs/Web/HTML/Element/input "The HTML &lt;input> element is used to 
create interactive controls for web-based forms in order to accept data from the user;
a wide variety of types of input data and control widgets are available, depending
on the device and user agent.") elements
```

We don't do anything with this title text and I just strip it out manually. This PR strips title attributes in the scraper.