### PR TITLE
Scrape BCD and interactive-examples front matter

### DIFF
--- a/scripts/scraper/scrape-front-matter.js
+++ b/scripts/scraper/scrape-front-matter.js
@@ -50,7 +50,7 @@ function extractBCD(html) {
 
 async function scrapeFrontMatter(title, url, md, isGuidePage) {
   const fullURL = `${baseURL}${url}`;
-  let frontMatter = `title: ${title}\nmdn_url: ${fullURL}\n`;
+  let frontMatter = `title: '${title}'\nmdn_url: ${fullURL}\n`;
   if (!isGuidePage) {
     const withMacrosURL = `${fullURL}?raw`;
     const getWithMacros = await fetch(withMacrosURL);

--- a/scripts/scraper/scrape-front-matter.js
+++ b/scripts/scraper/scrape-front-matter.js
@@ -14,7 +14,7 @@ function extractMacroArguments(macroName, html) {
     return null;
   }
   // Split by ",", then strip leading and trailing spaces and double-quotes
-  return matches[1].split(',').map(piece => piece.replace(/^[\"\ ]+|[\"\ ]+$/g, ''));
+  return matches[1].split(',').map(piece => piece.replace(/^[" ]+|[" ]+$/g, ''));
 }
 
 function getInteractiveExampleHeight(heightArgument) {
@@ -29,23 +29,23 @@ function getInteractiveExampleHeight(heightArgument) {
     case 'tabbed-taller':
         return 'html-tall';
     default:
-      throw(`Unexpected interactive example height: ${toMap}`);
+      throw(`Unexpected interactive example height: ${heightArgument}`);
   }
 }
 
 function extractInteractiveExample(html) {
-  const arguments = extractMacroArguments('EmbedInteractiveExample', html);
-  if (!arguments) {
+  const macroArgs = extractMacroArguments('EmbedInteractiveExample', html);
+  if (!macroArgs) {
     return '';
   }
-  const url = `https://interactive-examples.mdn.mozilla.net/${arguments[0]}`;
-  const height = getInteractiveExampleHeight(arguments[1]);
+  const url = `https://interactive-examples.mdn.mozilla.net/${macroArgs[0]}`;
+  const height = getInteractiveExampleHeight(macroArgs[1]);
   return `interactive_example:\n    url: ${url}\n    height: ${height}\n`;
 }
 
 function extractBCD(html) {
-  const arguments = extractMacroArguments('Compat', html);
-  return arguments? `browser_compatibility: ${arguments[0]}\n`: '';
+  const macroArgs = extractMacroArguments('Compat', html);
+  return macroArgs? `browser_compatibility: ${macroArgs[0]}\n`: '';
 }
 
 async function scrapeFrontMatter(title, url, md, isGuidePage) {

--- a/scripts/scraper/scrape-front-matter.js
+++ b/scripts/scraper/scrape-front-matter.js
@@ -1,0 +1,66 @@
+const fetch = require('node-fetch');
+
+const baseURL = 'https://developer.mozilla.org';
+
+/**
+ * Given the name of a macro and some HTML,
+ * find the first invocation of the macro in the HTML and return
+ * the arguments with which the macro was called.
+ */
+function extractMacroArguments(macroName, html) {
+  const regex = new RegExp(`{{\\ ?${macroName}\\((".*?")\\)}}`, 'i');
+  const matches = html.match(regex);
+  if (!matches || !matches[1]) {
+    return null;
+  }
+  // Split by ",", then strip leading and trailing spaces and double-quotes
+  return matches[1].split(',').map(piece => piece.replace(/^[\"\ ]+|[\"\ ]+$/g, ''));
+}
+
+function getInteractiveExampleHeight(heightArgument) {
+  if (!heightArgument) {
+    heightArgument = 'tabbed-standard';
+  }
+  switch (heightArgument) {
+    case 'tabbed-shorter':
+        return 'html-short';
+    case 'tabbed-standard':
+        return 'html-standard';
+    case 'tabbed-taller':
+        return 'html-tall';
+    default:
+      throw(`Unexpected interactive example height: ${toMap}`);
+  }
+}
+
+function extractInteractiveExample(html) {
+  const arguments = extractMacroArguments('EmbedInteractiveExample', html);
+  if (!arguments) {
+    return '';
+  }
+  const url = `https://interactive-examples.mdn.mozilla.net/${arguments[0]}`;
+  const height = getInteractiveExampleHeight(arguments[1]);
+  return `interactive_example:\n    url: ${url}\n    height: ${height}\n`;
+}
+
+function extractBCD(html) {
+  const arguments = extractMacroArguments('Compat', html);
+  return arguments? `browser_compatibility: ${arguments[0]}\n`: '';
+}
+
+async function scrapeFrontMatter(title, url, md, isGuidePage) {
+  const fullURL = `${baseURL}${url}`;
+  let frontMatter = `title: ${title}\nmdn_url: ${fullURL}\n`;
+  if (!isGuidePage) {
+    const withMacrosURL = `${fullURL}?raw`;
+    const getWithMacros = await fetch(withMacrosURL);
+    const htmlWithMacros = await getWithMacros.text();
+    frontMatter += extractInteractiveExample(htmlWithMacros);
+    frontMatter += extractBCD(htmlWithMacros);
+  }
+  return `---\n${frontMatter}---\n${md}`;
+}
+
+module.exports = {
+    scrapeFrontMatter
+};

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -25,13 +25,17 @@ const parse = require('rehype-parse');
 const stringify = require('remark-stringify');
 const rehype2remark = require('rehype-remark');
 
-const fetch = require("node-fetch");
+const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 
+const { scrapeFrontMatter } = require('./scrape-front-matter.js');
+
 const baseURL = 'https://developer.mozilla.org';
+
+let isGuidePage = false;
 
 /**
  * Converts the HTML -> Markdown using unified.
@@ -54,11 +58,6 @@ function writeDoc(subpath, name, doc) {
     fs.mkdirSync(destDir, { recursive: true });
   }
   fs.writeFileSync(dest, doc);
-}
-
-function addFrontMatter(title, url, md) {
-  const fullURL = `${baseURL}${url}`;
-  return `---\ntitle: ${title}\nmdn_url: ${fullURL}\n---\n${md}`;
 }
 
 /**
@@ -100,7 +99,7 @@ function getPageJSON(url) {
 async function processDoc(relativeURL, title, destination) {
   const absoluteURL = baseURL + relativeURL;
   const md = String(await processSingleDocContent(absoluteURL));
-  const doc = addFrontMatter(title, relativeURL, md);
+  const doc = await scrapeFrontMatter(title, relativeURL, md, isGuidePage);
   writeDoc(destination, relativeURL.split('/').pop(), doc);
 }
 
@@ -110,6 +109,9 @@ async function processDoc(relativeURL, title, destination) {
  * Otherwise just process the given page.
  */
 async function main(args) {
+  if (args.includes('--guide-page')) {
+    isGuidePage = true;
+  }
   if (args.includes('--scrape-children')) {
     const childrenJSON = await getPageJSON(args[0] + '$children');
     childrenJSON.subpages.map(child => {


### PR DESCRIPTION
This PR makes the scraper scrape BCD and interactive-example front matter from the Wiki. It only works for recipe-based pages, so it also adds a new flag "--guide-page". If this flag is passed, the behavior is suppressed.

(We would want to do something different for guide pages, but since 80-90% of pages are reference pages, it's less important to make migration quicker.)

The next most important bits to scrape would be live samples, but that would be a lot harder.