### PR TITLE
Remove locale from mdn_url

### DIFF
--- a/content/html/HTML.md
+++ b/content/html/HTML.md
@@ -1,6 +1,6 @@
 ---
 title: "HTML: Hypertext Markup Language"
-mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML
+mdn_url: https://developer.mozilla.org/docs/Web/HTML
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/html/guides/Applying_color.md
+++ b/content/html/guides/Applying_color.md
@@ -1,6 +1,6 @@
 ---
 title: Applying color to HTML elements using CSS
-mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML/Applying_color
+mdn_url: https://developer.mozilla.org/docs/Web/HTML/Applying_color
 related_content: /content/related_content/html.yaml
 recipe: guide
 ---

--- a/content/html/reference/elements.md
+++ b/content/html/reference/elements.md
@@ -1,6 +1,6 @@
 ---
 title: HTML elements
-mdn_url: https://developer.mozilla.org/en-US/docs/HTML/Elements
+mdn_url: https://developer.mozilla.org/docs/HTML/Elements
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/learn/html/Introduction_to_HTML.md
+++ b/content/learn/html/Introduction_to_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Introduction to HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Advanced_text_formatting.md
+++ b/content/learn/html/Introduction_to_HTML/Advanced_text_formatting.md
@@ -1,5 +1,5 @@
 ---
 title: Advanced text formatting
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Creating_hyperlinks.md
+++ b/content/learn/html/Introduction_to_HTML/Creating_hyperlinks.md
@@ -1,5 +1,5 @@
 ---
 title: Creating hyperlinks
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Debugging_HTML.md
+++ b/content/learn/html/Introduction_to_HTML/Debugging_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Debugging HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Document_and_website_structure.md
+++ b/content/learn/html/Introduction_to_HTML/Document_and_website_structure.md
@@ -1,5 +1,5 @@
 ---
 title: Document and website structure
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Getting_started.md
+++ b/content/learn/html/Introduction_to_HTML/Getting_started.md
@@ -1,5 +1,5 @@
 ---
 title: Getting started with HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Getting_started
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/HTML_text_fundamentals.md
+++ b/content/learn/html/Introduction_to_HTML/HTML_text_fundamentals.md
@@ -1,5 +1,5 @@
 ---
 title: HTML text fundamentals
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Marking_up_a_letter.md
+++ b/content/learn/html/Introduction_to_HTML/Marking_up_a_letter.md
@@ -1,5 +1,5 @@
 ---
 title: Marking up a letter
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Structuring_a_page_of_content.md
+++ b/content/learn/html/Introduction_to_HTML/Structuring_a_page_of_content.md
@@ -1,5 +1,5 @@
 ---
 title: Structuring a page of content
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/The_head_metadata_in_HTML.md
+++ b/content/learn/html/Introduction_to_HTML/The_head_metadata_in_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: What’s in the head? Metadata in HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
 ---
 some content here

--- a/content/learn/html/Multimedia_and_embedding.md
+++ b/content/learn/html/Multimedia_and_embedding.md
@@ -1,5 +1,5 @@
 ---
 title: Multimedia and Embedding
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web.md
+++ b/content/learn/html/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web.md
@@ -1,5 +1,5 @@
 ---
 title: Adding vector graphics to the Web
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Images_in_HTML.md
+++ b/content/learn/html/Multimedia_and_embedding/Images_in_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Images in HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Mozilla_splash_page.md
+++ b/content/learn/html/Multimedia_and_embedding/Mozilla_splash_page.md
@@ -1,5 +1,5 @@
 ---
 title: Mozilla splash page
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Other_embedding_technologies.md
+++ b/content/learn/html/Multimedia_and_embedding/Other_embedding_technologies.md
@@ -1,5 +1,5 @@
 ---
 title: From object to iframe — other embedding technologies
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Responsive_images.md
+++ b/content/learn/html/Multimedia_and_embedding/Responsive_images.md
@@ -1,5 +1,5 @@
 ---
 title: Responsive images
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Video_and_audio_content.md
+++ b/content/learn/html/Multimedia_and_embedding/Video_and_audio_content.md
@@ -1,5 +1,5 @@
 ---
 title: Video and audio content
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
+mdn_url: https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 ---
 Some text here...


### PR DESCRIPTION
Note: this is not a fix for https://github.com/mdn/stumptown-content/issues/123, in fact it's the opposite, since in https://github.com/mdn/stumptown-content/issues/123, AFAICT, we're intending to keep the locale in `mdn_url`.

However, I was trying to get guide pages rendering, and realised that the example guide page here (https://github.com/mdn/stumptown-content/blob/master/content/html/guides/Applying_color.md) isn't getting shown in stumptown-renderer's server. I *think* this is because the `mdn_url` includes the locale, so the JSON is being put in "client/.build/**en-US**/docs/Web/HTML/Applying_color/index.json". But the server is looking in "client/.build/docs/Web/HTML/Applying_color/index.json". If I remove the locale from the JSON in stumptown/packaged/, then the server does find it.

So this PR updates `mdn_url` in all places to remove the locale, and after that it should be possible to figure out how to render guide pages.

If you would prefer to change `mdn_url` instead along the lines of https://github.com/mdn/stumptown-content/issues/123, then I'm happy to do that instead. But then AFAICT we'd need corresponding updates in stumptown-renderer.
