### PR TITLE
Updated mdn_url

### DIFF
--- a/content/html/HTML.md
+++ b/content/html/HTML.md
@@ -1,6 +1,6 @@
 ---
 title: "HTML: Hypertext Markup Language"
-mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML
+mdn_url: /en-US/en-US/docs/Web/HTML
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/html/HTML.md
+++ b/content/html/HTML.md
@@ -1,6 +1,6 @@
 ---
 title: "HTML: Hypertext Markup Language"
-mdn_url: /en-US/en-US/docs/Web/HTML
+mdn_url: /en-US/docs/Web/HTML
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/html/guides/Applying_color.md
+++ b/content/html/guides/Applying_color.md
@@ -1,6 +1,6 @@
 ---
 title: Applying color to HTML elements using CSS
-mdn_url: https://developer.mozilla.org/en-US/docs/Web/HTML/Applying_color
+mdn_url: /en-US/docs/Web/HTML/Applying_color
 related_content: /content/related_content/html.yaml
 recipe: guide
 ---

--- a/content/html/reference/elements.md
+++ b/content/html/reference/elements.md
@@ -1,6 +1,6 @@
 ---
 title: HTML elements
-mdn_url: https://developer.mozilla.org/en-US/docs/HTML/Elements
+mdn_url: /en-US/docs/HTML/Elements
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/html/reference/elements/abbr/docs.md
+++ b/content/html/reference/elements/abbr/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<abbr>: The Abbreviation element'
 short_title: <abbr>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/abbr
+mdn_url: /en-US/docs/Web/HTML/Element/abbr
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/address/docs.md
+++ b/content/html/reference/elements/address/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<address>: The Contact Address element'
 short_title: <address>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/address
+mdn_url: /en-US/docs/Web/HTML/Element/address
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/article/docs.md
+++ b/content/html/reference/elements/article/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<article>: The Article Contents element'
 short_title: <article>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/article
+mdn_url: /en-US/docs/Web/HTML/Element/article
 tags:
     group: Flow content
 api: HTMLElement

--- a/content/html/reference/elements/aside/docs.md
+++ b/content/html/reference/elements/aside/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<aside>: The Aside element'
 short_title: <aside>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/aside
+mdn_url: /en-US/docs/Web/HTML/Element/aside
 tags:
     group: Flow content
 api: HTMLElement

--- a/content/html/reference/elements/audio/docs.md
+++ b/content/html/reference/elements/audio/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<audio>: The Embed Audio element'
 short_title: <audio>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/audio
+mdn_url: /en-US/docs/Web/HTML/Element/audio
 tags:
     group: Image and multimedia
 api: HTMLAudioElement

--- a/content/html/reference/elements/b/docs.md
+++ b/content/html/reference/elements/b/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<b>: The Bring Attention To element'
 short_title: <b>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/b
+mdn_url: /en-US/docs/Web/HTML/Element/b
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/base/docs.md
+++ b/content/html/reference/elements/base/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<base>: The Document Base URL element'
 short_title: <base>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/base
+mdn_url: /en-US/docs/Web/HTML/Element/base
 tags:
     group: Document metadata
 api: HTMLBaseElement

--- a/content/html/reference/elements/bdi/docs.md
+++ b/content/html/reference/elements/bdi/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<bdi>: The Bidirectional Isolate element'
 short_title: <bdi>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/bdi
+mdn_url: /en-US/docs/Web/HTML/Element/bdi
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/bdo/docs.md
+++ b/content/html/reference/elements/bdo/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<bdo>: The Bidirectional Text Override element'
 short_title: <bdo>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/bdo
+mdn_url: /en-US/docs/Web/HTML/Element/bdo
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/blockquote/docs.md
+++ b/content/html/reference/elements/blockquote/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<blockquote>: The Block Quotation element'
 short_title: <blockquote>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/blockquote
+mdn_url: /en-US/docs/Web/HTML/Element/blockquote
 tags:
     group: Text content
 api: HTMLQuoteElement

--- a/content/html/reference/elements/body/docs.md
+++ b/content/html/reference/elements/body/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<body>: The Document Body element'
 short_title: <body>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/body
+mdn_url: /en-US/docs/Web/HTML/Element/body
 tags:
     group: Sectioning root
 api: HTMLBodyElement

--- a/content/html/reference/elements/br/docs.md
+++ b/content/html/reference/elements/br/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<br>: The Line Break element'
 short_title: <br>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/br
+mdn_url: /en-US/docs/Web/HTML/Element/br
 tags:
     group: Inline text semantics
 api: HTMLBRElement

--- a/content/html/reference/elements/button/docs.md
+++ b/content/html/reference/elements/button/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<button>: The Button element'
 short_title: <button>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/button
+mdn_url: /en-US/docs/Web/HTML/Element/button
 tags:
     group: Forms
 api: HTMLButtonElement

--- a/content/html/reference/elements/canvas/docs.md
+++ b/content/html/reference/elements/canvas/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<canvas>: The Graphics Canvas element'
 short_title: <canvas>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/canvas
+mdn_url: /en-US/docs/Web/HTML/Element/canvas
 tags:
     group: Scripting
 api: HTMLCanvasElement

--- a/content/html/reference/elements/caption/docs.md
+++ b/content/html/reference/elements/caption/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<caption>: The Table Caption element'
 short_title: <caption>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/caption
+mdn_url: /en-US/docs/Web/HTML/Element/caption
 tags:
     group: Table content
 api: HTMLTableCaptionElement

--- a/content/html/reference/elements/cite/docs.md
+++ b/content/html/reference/elements/cite/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<cite>: The Citation element'
 short_title: <cite>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/cite
+mdn_url: /en-US/docs/Web/HTML/Element/cite
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/code/docs.md
+++ b/content/html/reference/elements/code/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<code>: The Inline Code element'
 short_title: <code>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/code
+mdn_url: /en-US/docs/Web/HTML/Element/code
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/col/docs.md
+++ b/content/html/reference/elements/col/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<col>'
 short_title: <col>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/col
+mdn_url: /en-US/docs/Web/HTML/Element/col
 tags:
     group: Table content
 api: HTMLTableColElement

--- a/content/html/reference/elements/colgroup/docs.md
+++ b/content/html/reference/elements/colgroup/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<colgroup>'
 short_title: <colgroup>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/colgroup
+mdn_url: /en-US/docs/Web/HTML/Element/colgroup
 tags:
     group: Table content
 api: HTMLTableColElement

--- a/content/html/reference/elements/data/docs.md
+++ b/content/html/reference/elements/data/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<data>'
 short_title: <data>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/data
+mdn_url: /en-US/docs/Web/HTML/Element/data
 tags:
     group: Inline text semantics
 api: HTMLDataElement

--- a/content/html/reference/elements/datalist/docs.md
+++ b/content/html/reference/elements/datalist/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<datalist>'
 short_title: <datalist>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/datalist
+mdn_url: /en-US/docs/Web/HTML/Element/datalist
 tags:
     group: Forms
 api: HTMLDataListElement

--- a/content/html/reference/elements/dd/docs.md
+++ b/content/html/reference/elements/dd/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<dd>: The Description Details element'
 short_title: <dd>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dd
+mdn_url: /en-US/docs/Web/HTML/Element/dd
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/del/docs.md
+++ b/content/html/reference/elements/del/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<del>: The Deleted Text element'
 short_title: <del>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/del
+mdn_url: /en-US/docs/Web/HTML/Element/del
 tags:
     group: Demarcating edits
 api: HTMLModElement

--- a/content/html/reference/elements/details/docs.md
+++ b/content/html/reference/elements/details/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<details>: The Details disclosure element'
 short_title: <details>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/details
+mdn_url: /en-US/docs/Web/HTML/Element/details
 tags:
     group: Interactive elements
 api: HTMLDetailsElement

--- a/content/html/reference/elements/dfn/docs.md
+++ b/content/html/reference/elements/dfn/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<dfn>: The Definition element'
 short_title: <dfn>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dfn
+mdn_url: /en-US/docs/Web/HTML/Element/dfn
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/dialog/docs.md
+++ b/content/html/reference/elements/dialog/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<dialog>: The Dialog element'
 short_title: <dialog>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dialog
+mdn_url: /en-US/docs/Web/HTML/Element/dialog
 tags:
     group: Interactive elements
 api: HTMLDialogElement

--- a/content/html/reference/elements/div/docs.md
+++ b/content/html/reference/elements/div/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<div>: The Content Division element'
 short_title: <div>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/div
+mdn_url: /en-US/docs/Web/HTML/Element/div
 tags:
     group: Text content
 api: HTMLDivElement

--- a/content/html/reference/elements/dl/docs.md
+++ b/content/html/reference/elements/dl/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<dl>: The Description List element'
 short_title: <dl>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dl
+mdn_url: /en-US/docs/Web/HTML/Element/dl
 tags:
     group: Text content
 api: HTMLDListElement

--- a/content/html/reference/elements/dt/docs.md
+++ b/content/html/reference/elements/dt/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<dt>: The Description Term element'
 short_title: <dt>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/dt
+mdn_url: /en-US/docs/Web/HTML/Element/dt
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/em/docs.md
+++ b/content/html/reference/elements/em/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<em>: The Emphasis element'
 short_title: <em>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/em
+mdn_url: /en-US/docs/Web/HTML/Element/em
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/embed/docs.md
+++ b/content/html/reference/elements/embed/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<embed>: The Embed External Content element'
 short_title: <embed>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/embed
+mdn_url: /en-US/docs/Web/HTML/Element/embed
 tags:
     group: Embedded content
 api: HTMLEmbedElement

--- a/content/html/reference/elements/fieldset/docs.md
+++ b/content/html/reference/elements/fieldset/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<fieldset>: The Field Set element'
 short_title: <fieldset>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/fieldset
+mdn_url: /en-US/docs/Web/HTML/Element/fieldset
 tags:
     group: Forms
 api: HTMLFieldSetElement

--- a/content/html/reference/elements/figcaption/docs.md
+++ b/content/html/reference/elements/figcaption/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<figcaption>'
 short_title: <figcaption>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/figcaption
+mdn_url: /en-US/docs/Web/HTML/Element/figcaption
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/figure/docs.md
+++ b/content/html/reference/elements/figure/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<figure>'
 short_title: <figure>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/figure
+mdn_url: /en-US/docs/Web/HTML/Element/figure
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/footer/docs.md
+++ b/content/html/reference/elements/footer/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<footer>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/footer
+mdn_url: /en-US/docs/Web/HTML/Element/footer
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/form/docs.md
+++ b/content/html/reference/elements/form/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<form>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/form
+mdn_url: /en-US/docs/Web/HTML/Element/form
 tags:
     group: Forms
 api: HTMLFormElement

--- a/content/html/reference/elements/h1-h6/docs.md
+++ b/content/html/reference/elements/h1-h6/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<h1>–<h6>: The HTML Section Heading elements'
 short_title: <h1>-<h6>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements
+mdn_url: /en-US/docs/Web/HTML/Element/Heading_Elements
 tags:
     group: Content sectioning
 api: HTMLHeadingElement

--- a/content/html/reference/elements/head/docs.md
+++ b/content/html/reference/elements/head/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<head>: The Document Metadata (Header) element'
 short_title: <head>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/head
+mdn_url: /en-US/docs/Web/HTML/Element/head
 tags:
     group: Document metadata
 api: HTMLHeadElement

--- a/content/html/reference/elements/header/docs.md
+++ b/content/html/reference/elements/header/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<header>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/header
+mdn_url: /en-US/docs/Web/HTML/Element/header
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/hr/docs.md
+++ b/content/html/reference/elements/hr/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<hr>: The Thematic Break (Horizontal Rule) element'
 short_title: <hr>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/hr
+mdn_url: /en-US/docs/Web/HTML/Element/hr
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/html/docs.md
+++ b/content/html/reference/elements/html/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<html>: The HTML Document / Root element'
 short_title: <html>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/html
+mdn_url: /en-US/docs/Web/HTML/Element/html
 tags:
     group: Main root
 api: HTMLHtmlElement

--- a/content/html/reference/elements/i/docs.md
+++ b/content/html/reference/elements/i/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<i>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/i
+mdn_url: /en-US/docs/Web/HTML/Element/i
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/iframe/docs.md
+++ b/content/html/reference/elements/iframe/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<iframe>: The Inline Frame element'
 short_title: <iframe>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/iframe
+mdn_url: /en-US/docs/Web/HTML/Element/iframe
 tags:
     group: Embedded content
 api: HTMLIFrameElement

--- a/content/html/reference/elements/ins/docs.md
+++ b/content/html/reference/elements/ins/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<ins>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/ins
+mdn_url: /en-US/docs/Web/HTML/Element/ins
 tags:
     group: Inline text semantics
 api: HTMLModElement

--- a/content/html/reference/elements/kbd/docs.md
+++ b/content/html/reference/elements/kbd/docs.md
@@ -1,7 +1,7 @@
 ---
 title: '<kbd>: The Keyboard Input element'
 short_title: <kbd>
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/kbd
+mdn_url: /en-US/docs/Web/HTML/Element/kbd
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/label/docs.md
+++ b/content/html/reference/elements/label/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<label>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/label
+mdn_url: /en-US/docs/Web/HTML/Element/label
 tags:
     group: Forms
 api: HTMLLabelElement

--- a/content/html/reference/elements/legend/docs.md
+++ b/content/html/reference/elements/legend/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<legend>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/legend
+mdn_url: /en-US/docs/Web/HTML/Element/legend
 tags:
     group: Forms
 api: HTMLLegendElement

--- a/content/html/reference/elements/li/docs.md
+++ b/content/html/reference/elements/li/docs.md
@@ -1,6 +1,6 @@
 ---
 title: '<li>'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/li
+mdn_url: /en-US/docs/Web/HTML/Element/li
 tags:
     group: Text content
 api: HTMLLIElement

--- a/content/html/reference/elements/table/docs.md
+++ b/content/html/reference/elements/table/docs.md
@@ -1,6 +1,7 @@
 ---
 title: '<table>: The Table element'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/table
+short_title: <table>
+mdn_url: /en-US/docs/Web/HTML/Element/table
 tags:
     group: Flow content
 api: HTMLTableElement

--- a/content/html/reference/elements/video/docs.md
+++ b/content/html/reference/elements/video/docs.md
@@ -1,6 +1,7 @@
 ---
 title: '<video>: The Video Embed element'
-mdn_url: https://developer.mozilla.org/docs/Web/HTML/Element/video
+short_title: <video>
+mdn_url: /en-US/docs/Web/HTML/Element/video
 tags:
     group: Image and multimedia
 api: HTMLVideoElement

--- a/content/learn/html/Introduction_to_HTML.md
+++ b/content/learn/html/Introduction_to_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Introduction to HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Advanced_text_formatting.md
+++ b/content/learn/html/Introduction_to_HTML/Advanced_text_formatting.md
@@ -1,5 +1,5 @@
 ---
 title: Advanced text formatting
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Creating_hyperlinks.md
+++ b/content/learn/html/Introduction_to_HTML/Creating_hyperlinks.md
@@ -1,5 +1,5 @@
 ---
 title: Creating hyperlinks
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Debugging_HTML.md
+++ b/content/learn/html/Introduction_to_HTML/Debugging_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Debugging HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Debugging_HTML
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Document_and_website_structure.md
+++ b/content/learn/html/Introduction_to_HTML/Document_and_website_structure.md
@@ -1,5 +1,5 @@
 ---
 title: Document and website structure
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Getting_started.md
+++ b/content/learn/html/Introduction_to_HTML/Getting_started.md
@@ -1,5 +1,5 @@
 ---
 title: Getting started with HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/HTML_text_fundamentals.md
+++ b/content/learn/html/Introduction_to_HTML/HTML_text_fundamentals.md
@@ -1,5 +1,5 @@
 ---
 title: HTML text fundamentals
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Marking_up_a_letter.md
+++ b/content/learn/html/Introduction_to_HTML/Marking_up_a_letter.md
@@ -1,5 +1,5 @@
 ---
 title: Marking up a letter
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/Structuring_a_page_of_content.md
+++ b/content/learn/html/Introduction_to_HTML/Structuring_a_page_of_content.md
@@ -1,5 +1,5 @@
 ---
 title: Structuring a page of content
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
 ---
 some content here

--- a/content/learn/html/Introduction_to_HTML/The_head_metadata_in_HTML.md
+++ b/content/learn/html/Introduction_to_HTML/The_head_metadata_in_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: What’s in the head? Metadata in HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
+mdn_url: /en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
 ---
 some content here

--- a/content/learn/html/Multimedia_and_embedding.md
+++ b/content/learn/html/Multimedia_and_embedding.md
@@ -1,5 +1,5 @@
 ---
 title: Multimedia and Embedding
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web.md
+++ b/content/learn/html/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web.md
@@ -1,5 +1,5 @@
 ---
 title: Adding vector graphics to the Web
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Images_in_HTML.md
+++ b/content/learn/html/Multimedia_and_embedding/Images_in_HTML.md
@@ -1,5 +1,5 @@
 ---
 title: Images in HTML
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Mozilla_splash_page.md
+++ b/content/learn/html/Multimedia_and_embedding/Mozilla_splash_page.md
@@ -1,5 +1,5 @@
 ---
 title: Mozilla splash page
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Other_embedding_technologies.md
+++ b/content/learn/html/Multimedia_and_embedding/Other_embedding_technologies.md
@@ -1,5 +1,5 @@
 ---
 title: From object to iframe — other embedding technologies
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Responsive_images.md
+++ b/content/learn/html/Multimedia_and_embedding/Responsive_images.md
@@ -1,5 +1,5 @@
 ---
 title: Responsive images
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
 ---
 Some text here...

--- a/content/learn/html/Multimedia_and_embedding/Video_and_audio_content.md
+++ b/content/learn/html/Multimedia_and_embedding/Video_and_audio_content.md
@@ -1,5 +1,5 @@
 ---
 title: Video and audio content
-mdn_url: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
+mdn_url: /en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 ---
 Some text here...


### PR DESCRIPTION
This is (possibly) a fix for https://github.com/mdn/stumptown-content/issues/123.

It changes `mdn_url` everywhere to be of the form:

    /en-US/docs/path/to/page

Note that this PR will break the renderer.