### PR TITLE
Fix a couple of scraper issues

### DIFF
--- a/scripts/scraper/process-macros/process-live-samples.js
+++ b/scripts/scraper/process-macros/process-live-samples.js
@@ -125,7 +125,7 @@ async function extractLiveSample(macroArgs, dom, examplesDir) {
 async function processLiveSamples(htmlWithMacroCalls, result, destination) {
   const macroCalls = extractMacroCalls('EmbedLiveSample', htmlWithMacroCalls);
   const examplesDir = path.join(process.cwd(), destination, 'examples');
-  if (macroCalls) {
+  if (macroCalls.length) {
     let lsFrontMatter = 'examples:\n';
     lsFrontMatter += macroCalls.map(macroCall => `    - examples/${macroCall[0]}\n`).join('');
     result.frontMatter += lsFrontMatter;

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -89,7 +89,7 @@ async function processDoc(relativeURL, title, destination) {
   removeNode(dom, 'section.Quick_links');
   const result = await processMacros(dom, relativeURL, destination);
   const md = String(await toMarkdown(result.dom.serialize()));
-  const frontMatter = `---\ntitle: '${title}'\nmdn_url: ${baseURL + relativeURL}\n${result.frontMatter}---\n`;
+  const frontMatter = `---\ntitle: '${title}'\nmdn_url: ${relativeURL}\n${result.frontMatter}---\n`;
   writeDoc(destination, relativeURL.split('/').pop(), `${frontMatter}${md}\n`);
 }
 


### PR DESCRIPTION
This fixes a couple of small but annoying scraper issues:

* we now want `mdn_url` to be a relative path (omitting "https://developer.mozilla.org")
* the test for whether there were any live samples macro calls was buggy, which made it create an "examples" directory and add the "examples" front matter property even if there weren't any calls.

