### PR TITLE
include query used for bcd resolution

### DIFF
--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -15,7 +15,7 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
             }
             return packageInteractiveExample(data.interactive_example);
         case 'browser_compatibility':
-            return packageBCD(data.browser_compatibility);
+            return {query: data.browser_compatibility, data: packageBCD(data.browser_compatibility)};
         case 'attributes':
             if (data.attributes.element_specific) {
                 return await packageAttributes(elementPath, data.attributes.element_specific);


### PR DESCRIPTION
Basically, this reveals the BCD query (e.g. `html.elements.link.rel`) back in the packaged JSON so that the renderer can extract that primary name (e.g. `rel`) when it builds up the rows. 