### PR TITLE
Add spec data and build it to packaged output

### DIFF
--- a/content/data/specifications.json
+++ b/content/data/specifications.json
@@ -1,6 +1,0 @@
-{
-  "html.spec.whatwg.org": "WHATWG HTML Living Standard",
-  "w3c.github.io/webappsec-cspee": "Content Security Policy: Embedded Enforcement",
-  "w3c.github.io/webappsec-feature-policy": "Feature Policy",
-  "wicg.github.io/priority-hints": "Priority Hints"
-}

--- a/content/data/specifications.json
+++ b/content/data/specifications.json
@@ -1,0 +1,6 @@
+{
+  "html.spec.whatwg.org": "WHATWG HTML Living Standard",
+  "w3c.github.io/webappsec-cspee": "Content Security Policy: Embedded Enforcement",
+  "w3c.github.io/webappsec-feature-policy": "Feature Policy",
+  "wicg.github.io/priority-hints": "Priority Hints"
+}

--- a/content/data/specifications.yaml
+++ b/content/data/specifications.yaml
@@ -1,0 +1,7 @@
+# Allowed specification domains and their titles
+# Never add historical specfications to this allow list
+
+html.spec.whatwg.org: 'WHATWG HTML Living Standard'
+w3c.github.io/webappsec-cspee": 'Content Security Policy: Embedded Enforcement'
+w3c.github.io/webappsec-feature-policy: 'Feature Policy'
+wicg.github.io/priority-hints: 'Priority Hints'

--- a/content/data/specifications.yaml
+++ b/content/data/specifications.yaml
@@ -2,6 +2,6 @@
 # Never add historical specfications to this allow list
 
 html.spec.whatwg.org: 'WHATWG HTML Living Standard'
-w3c.github.io/webappsec-cspee": 'Content Security Policy: Embedded Enforcement'
+w3c.github.io/webappsec-cspee: 'Content Security Policy: Embedded Enforcement'
 w3c.github.io/webappsec-feature-policy: 'Feature Policy'
 wicg.github.io/priority-hints: 'Priority Hints'

--- a/content/html/HTML.md
+++ b/content/html/HTML.md
@@ -1,7 +1,7 @@
 ---
 title: "HTML: Hypertext Markup Language"
 mdn_url: /en-US/docs/Web/HTML
-spec_url: https://html.spec.whatwg.org/multipage/
+specifications: https://html.spec.whatwg.org/multipage/
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:

--- a/content/html/reference/elements/abbr/abbr.md
+++ b/content/html/reference/elements/abbr/abbr.md
@@ -2,7 +2,7 @@
 title: '<abbr>: The Abbreviation element'
 short_title: <abbr>
 mdn_url: /en-US/docs/Web/HTML/Element/abbr
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-abbr-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-abbr-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/address/address.md
+++ b/content/html/reference/elements/address/address.md
@@ -2,7 +2,7 @@
 title: '<address>: The Contact Address element'
 short_title: <address>
 mdn_url: /en-US/docs/Web/HTML/Element/address
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-address-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-address-element
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/article/article.md
+++ b/content/html/reference/elements/article/article.md
@@ -2,7 +2,7 @@
 title: '<article>: The Article Contents element'
 short_title: <article>
 mdn_url: /en-US/docs/Web/HTML/Element/article
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-article-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-article-element
 tags:
     group: Flow content
 api: HTMLElement

--- a/content/html/reference/elements/aside/aside.md
+++ b/content/html/reference/elements/aside/aside.md
@@ -2,7 +2,7 @@
 title: '<aside>: The Aside element'
 short_title: <aside>
 mdn_url: /en-US/docs/Web/HTML/Element/aside
-spec_url: https://html.spec.whatwg.org/multipage/sections.html#the-aside-element
+specifications: https://html.spec.whatwg.org/multipage/sections.html#the-aside-element
 tags:
     group: Flow content
 api: HTMLElement

--- a/content/html/reference/elements/audio/attributes/autoplay.md
+++ b/content/html/reference/elements/audio/attributes/autoplay.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.autoplay
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay
 ---
 
 # `autoplay`

--- a/content/html/reference/elements/audio/attributes/controls.md
+++ b/content/html/reference/elements/audio/attributes/controls.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.controls
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-controls
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-controls
 ---
 
 # `controls`

--- a/content/html/reference/elements/audio/attributes/crossorigin.md
+++ b/content/html/reference/elements/audio/attributes/crossorigin.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.crossorigin
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
 ---
 
 # `crossorigin`

--- a/content/html/reference/elements/audio/attributes/loop.md
+++ b/content/html/reference/elements/audio/attributes/loop.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.loop
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-loop
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-loop
 ---
 
 # `loop`

--- a/content/html/reference/elements/audio/attributes/muted.md
+++ b/content/html/reference/elements/audio/attributes/muted.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.muted
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-muted
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-muted
 ---
 
 # `muted`

--- a/content/html/reference/elements/audio/attributes/preload.md
+++ b/content/html/reference/elements/audio/attributes/preload.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.preload
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
 ---
 
 # `preload`

--- a/content/html/reference/elements/audio/attributes/src.md
+++ b/content/html/reference/elements/audio/attributes/src.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.audio.src
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-src
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-src
 ---
 
 # `src`

--- a/content/html/reference/elements/audio/audio.md
+++ b/content/html/reference/elements/audio/audio.md
@@ -2,7 +2,7 @@
 title: '<audio>: The Embed Audio element'
 short_title: <audio>
 mdn_url: /en-US/docs/Web/HTML/Element/audio
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content.html#the-audio-element
+specifications: https://html.spec.whatwg.org/multipage/embedded-content.html#the-audio-element
 tags:
     group: Image and multimedia
 api: HTMLAudioElement

--- a/content/html/reference/elements/b/b.md
+++ b/content/html/reference/elements/b/b.md
@@ -2,7 +2,7 @@
 title: '<b>: The Bring Attention To element'
 short_title: <b>
 mdn_url: /en-US/docs/Web/HTML/Element/b
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-b-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-b-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/base/attributes/href.md
+++ b/content/html/reference/elements/base/attributes/href.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.base.href
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href
 ---
 
 # `href`

--- a/content/html/reference/elements/base/attributes/target.md
+++ b/content/html/reference/elements/base/attributes/target.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.base.target
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#attr-base-target
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#attr-base-target
 ---
 
 # `target`

--- a/content/html/reference/elements/base/base.md
+++ b/content/html/reference/elements/base/base.md
@@ -2,7 +2,7 @@
 title: '<base>: The Document Base URL element'
 short_title: <base>
 mdn_url: /en-US/docs/Web/HTML/Element/base
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-base-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-base-element
 tags:
     group: Document metadata
 api: HTMLBaseElement

--- a/content/html/reference/elements/bdi/bdi.md
+++ b/content/html/reference/elements/bdi/bdi.md
@@ -2,7 +2,7 @@
 title: '<bdi>: The Bidirectional Isolate element'
 short_title: <bdi>
 mdn_url: /en-US/docs/Web/HTML/Element/bdi
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-bdi-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-bdi-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/bdo/bdo.md
+++ b/content/html/reference/elements/bdo/bdo.md
@@ -2,7 +2,7 @@
 title: '<bdo>: The Bidirectional Text Override element'
 short_title: <bdo>
 mdn_url: /en-US/docs/Web/HTML/Element/bdo
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-bdo-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-bdo-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/blockquote/attributes/cite.md
+++ b/content/html/reference/elements/blockquote/attributes/cite.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.blockquote.cite
-spec_url: https://html.spec.whatwg.org/multipage/grouping-content.html#attr-blockquote-cite
+specifications: https://html.spec.whatwg.org/multipage/grouping-content.html#attr-blockquote-cite
 ---
 
 # `cite`

--- a/content/html/reference/elements/blockquote/blockquote.md
+++ b/content/html/reference/elements/blockquote/blockquote.md
@@ -2,7 +2,7 @@
 title: '<blockquote>: The Block Quotation element'
 short_title: <blockquote>
 mdn_url: /en-US/docs/Web/HTML/Element/blockquote
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-blockquote-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-blockquote-element
 tags:
     group: Text content
 api: HTMLQuoteElement

--- a/content/html/reference/elements/body/attributes/onafterprint.md
+++ b/content/html/reference/elements/body/attributes/onafterprint.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onafterprint
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onafterprint
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onafterprint
 ---
 
 # `onafterprint`

--- a/content/html/reference/elements/body/attributes/onbeforeprint.md
+++ b/content/html/reference/elements/body/attributes/onbeforeprint.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onbeforeprint
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onbeforeprint
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onbeforeprint
 ---
 
 # `onbeforeprint`

--- a/content/html/reference/elements/body/attributes/onbeforeunload.md
+++ b/content/html/reference/elements/body/attributes/onbeforeunload.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onbeforeunload
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onbeforeunload
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onbeforeunload
 ---
 
 # `onbeforeunload`

--- a/content/html/reference/elements/body/attributes/onhashchange.md
+++ b/content/html/reference/elements/body/attributes/onhashchange.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onhashchange
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onhashchange
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onhashchange
 ---
 
 # `onhashchange`

--- a/content/html/reference/elements/body/attributes/onlanguagechange.md
+++ b/content/html/reference/elements/body/attributes/onlanguagechange.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onlanguagechange
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onlanguagechange
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onlanguagechange
 ---
 
 # `onlanguagechange`

--- a/content/html/reference/elements/body/attributes/onmessage.md
+++ b/content/html/reference/elements/body/attributes/onmessage.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onmessage
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onmessage
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onmessage
 ---
 
 # `onmessage`

--- a/content/html/reference/elements/body/attributes/onoffline.md
+++ b/content/html/reference/elements/body/attributes/onoffline.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onoffline
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onoffline
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onoffline
 ---
 
 # `onoffline`

--- a/content/html/reference/elements/body/attributes/ononline.md
+++ b/content/html/reference/elements/body/attributes/ononline.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.ononline
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-ononline
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-ononline
 ---
 
 # `ononline`

--- a/content/html/reference/elements/body/attributes/onpopstate.md
+++ b/content/html/reference/elements/body/attributes/onpopstate.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onpopstate
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onpopstate
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onpopstate
 ---
 
 # `onpopstate`

--- a/content/html/reference/elements/body/attributes/onstorage.md
+++ b/content/html/reference/elements/body/attributes/onstorage.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onstorage
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onstorage
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onstorage
 ---
 
 # `onstorage`

--- a/content/html/reference/elements/body/attributes/onunload.md
+++ b/content/html/reference/elements/body/attributes/onunload.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.body.onunload
-spec_url: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onunload
+specifications: https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onunload
 ---
 
 # `onunload`

--- a/content/html/reference/elements/body/body.md
+++ b/content/html/reference/elements/body/body.md
@@ -2,7 +2,7 @@
 title: '<body>: The Document Body element'
 short_title: <body>
 mdn_url: /en-US/docs/Web/HTML/Element/body
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-body-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-body-element
 tags:
     group: Sectioning root
 api: HTMLBodyElement

--- a/content/html/reference/elements/br/attributes/clear.md
+++ b/content/html/reference/elements/br/attributes/clear.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.br.clear
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-br-clear
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-br-clear
 ---
 
 # `clear`

--- a/content/html/reference/elements/br/br.md
+++ b/content/html/reference/elements/br/br.md
@@ -2,7 +2,7 @@
 title: '<br>: The Line Break element'
 short_title: <br>
 mdn_url: /en-US/docs/Web/HTML/Element/br
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-br-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-br-element
 tags:
     group: Inline text semantics
 api: HTMLBRElement

--- a/content/html/reference/elements/button/attributes/autocomplete.md
+++ b/content/html/reference/elements/button/attributes/autocomplete.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.autocomplete
-spec_url: non-standard
+specifications: non-standard
 ---
 
 # `autocomplete`

--- a/content/html/reference/elements/button/attributes/disabled.md
+++ b/content/html/reference/elements/button/attributes/disabled.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.disabled
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
 ---
 
 # `disabled`

--- a/content/html/reference/elements/button/attributes/form.md
+++ b/content/html/reference/elements/button/attributes/form.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.form
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
 ---
 
 # `form`

--- a/content/html/reference/elements/button/attributes/formaction.md
+++ b/content/html/reference/elements/button/attributes/formaction.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.formaction
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formaction
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formaction
 ---
 
 # `formaction`

--- a/content/html/reference/elements/button/attributes/formenctype.md
+++ b/content/html/reference/elements/button/attributes/formenctype.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.formenctype
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formenctype
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formenctype
 ---
 
 # `formenctype`

--- a/content/html/reference/elements/button/attributes/formmethod.md
+++ b/content/html/reference/elements/button/attributes/formmethod.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.formmethod
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formmethod
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formmethod
 ---
 
 # `formmethod`

--- a/content/html/reference/elements/button/attributes/formnovalidate.md
+++ b/content/html/reference/elements/button/attributes/formnovalidate.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.formnovalidate
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formnovalidate
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formnovalidate
 ---
 
 # `formnovalidate`

--- a/content/html/reference/elements/button/attributes/formtarget.md
+++ b/content/html/reference/elements/button/attributes/formtarget.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.formtarget
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formtarget
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formtarget
 ---
 
 # `formtarget`

--- a/content/html/reference/elements/button/attributes/name.md
+++ b/content/html/reference/elements/button/attributes/name.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.name
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
 ---
 
 # `name`

--- a/content/html/reference/elements/button/attributes/type.md
+++ b/content/html/reference/elements/button/attributes/type.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.type
-spec_url: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type
+specifications: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type
 ---
 
 # `type`

--- a/content/html/reference/elements/button/attributes/value.md
+++ b/content/html/reference/elements/button/attributes/value.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.button.value
-spec_url: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-value
+specifications: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-value
 ---
 
 # `value`

--- a/content/html/reference/elements/button/button.md
+++ b/content/html/reference/elements/button/button.md
@@ -2,7 +2,7 @@
 title: '<button>: The Button element'
 short_title: <button>
 mdn_url: /en-US/docs/Web/HTML/Element/button
-spec_url: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element
+specifications: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element
 tags:
     group: Forms
 api: HTMLButtonElement

--- a/content/html/reference/elements/canvas/attributes/height.md
+++ b/content/html/reference/elements/canvas/attributes/height.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.canvas.height
-spec_url: https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-height
+specifications: https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-height
 ---
 
 # `height`

--- a/content/html/reference/elements/canvas/attributes/moz-opaque.md
+++ b/content/html/reference/elements/canvas/attributes/moz-opaque.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.canvas.moz-opaque
-spec_url: non-standard
+specifications: non-standard
 ---
 
 # `moz-opaque`

--- a/content/html/reference/elements/canvas/attributes/width.md
+++ b/content/html/reference/elements/canvas/attributes/width.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.canvas.width
-spec_url: https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-width
+specifications: https://html.spec.whatwg.org/multipage/canvas.html#attr-canvas-width
 ---
 
 # `width`

--- a/content/html/reference/elements/canvas/canvas.md
+++ b/content/html/reference/elements/canvas/canvas.md
@@ -2,7 +2,7 @@
 title: '<canvas>: The Graphics Canvas element'
 short_title: <canvas>
 mdn_url: /en-US/docs/Web/HTML/Element/canvas
-spec_url: https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element
+specifications: https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element
 tags:
     group: Scripting
 api: HTMLCanvasElement

--- a/content/html/reference/elements/caption/caption.md
+++ b/content/html/reference/elements/caption/caption.md
@@ -2,7 +2,7 @@
 title: '<caption>: The Table Caption element'
 short_title: <caption>
 mdn_url: /en-US/docs/Web/HTML/Element/caption
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#the-caption-element
+specifications: https://html.spec.whatwg.org/multipage/tables.html#the-caption-element
 tags:
     group: Table content
 api: HTMLTableCaptionElement

--- a/content/html/reference/elements/cite/cite.md
+++ b/content/html/reference/elements/cite/cite.md
@@ -2,7 +2,7 @@
 title: '<cite>: The Citation element'
 short_title: <cite>
 mdn_url: /en-US/docs/Web/HTML/Element/cite
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-cite-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-cite-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/code/code.md
+++ b/content/html/reference/elements/code/code.md
@@ -2,7 +2,7 @@
 title: '<code>: The Inline Code element'
 short_title: <code>
 mdn_url: /en-US/docs/Web/HTML/Element/code
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-code-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-code-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/col/attributes/span.md
+++ b/content/html/reference/elements/col/attributes/span.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.col.span
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#attr-col-span
+specifications: https://html.spec.whatwg.org/multipage/tables.html#attr-col-span
 ---
 
 # `span`

--- a/content/html/reference/elements/col/col.md
+++ b/content/html/reference/elements/col/col.md
@@ -2,7 +2,7 @@
 title: '<col>'
 short_title: <col>
 mdn_url: /en-US/docs/Web/HTML/Element/col
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#the-col-element
+specifications: https://html.spec.whatwg.org/multipage/tables.html#the-col-element
 tags:
     group: Table content
 api: HTMLTableColElement

--- a/content/html/reference/elements/colgroup/attributes/span.md
+++ b/content/html/reference/elements/colgroup/attributes/span.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.colgroup.span
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#attr-colgroup-span
+specifications: https://html.spec.whatwg.org/multipage/tables.html#attr-colgroup-span
 ---
 
 # `span`

--- a/content/html/reference/elements/colgroup/colgroup.md
+++ b/content/html/reference/elements/colgroup/colgroup.md
@@ -2,7 +2,7 @@
 title: '<colgroup>'
 short_title: <colgroup>
 mdn_url: /en-US/docs/Web/HTML/Element/colgroup
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element
+specifications: https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element
 tags:
     group: Table content
 api: HTMLTableColElement

--- a/content/html/reference/elements/data/attributes/value.md
+++ b/content/html/reference/elements/data/attributes/value.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.data.value
-spec_url: https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-data-value
+specifications: https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-data-value
 ---
 
 # `value`

--- a/content/html/reference/elements/data/data.md
+++ b/content/html/reference/elements/data/data.md
@@ -2,7 +2,7 @@
 title: '<data>'
 short_title: <data>
 mdn_url: /en-US/docs/Web/HTML/Element/data
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-data-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-data-element
 tags:
     group: Inline text semantics
 api: HTMLDataElement

--- a/content/html/reference/elements/datalist/datalist.md
+++ b/content/html/reference/elements/datalist/datalist.md
@@ -2,7 +2,7 @@
 title: '<datalist>'
 short_title: <datalist>
 mdn_url: /en-US/docs/Web/HTML/Element/datalist
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#the-datalist-element
+specifications: https://html.spec.whatwg.org/multipage/forms.html#the-datalist-element
 tags:
     group: Forms
 api: HTMLDataListElement

--- a/content/html/reference/elements/dd/dd.md
+++ b/content/html/reference/elements/dd/dd.md
@@ -2,7 +2,7 @@
 title: '<dd>: The Description Details element'
 short_title: <dd>
 mdn_url: /en-US/docs/Web/HTML/Element/dd
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-dd-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-dd-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/del/attributes/cite.md
+++ b/content/html/reference/elements/del/attributes/cite.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.del.cite
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-cite
+specifications: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-cite
 ---
 
 # `cite`

--- a/content/html/reference/elements/del/attributes/datetime.md
+++ b/content/html/reference/elements/del/attributes/datetime.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.del.datetime
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-datetime
+specifications: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-datetime
 ---
 
 # `datetime`

--- a/content/html/reference/elements/del/del.md
+++ b/content/html/reference/elements/del/del.md
@@ -2,7 +2,7 @@
 title: '<del>: The Deleted Text element'
 short_title: <del>
 mdn_url: /en-US/docs/Web/HTML/Element/del
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#the-del-element
+specifications: https://html.spec.whatwg.org/multipage/edits.html#the-del-element
 tags:
     group: Demarcating edits
 api: HTMLModElement

--- a/content/html/reference/elements/details/attributes/open.md
+++ b/content/html/reference/elements/details/attributes/open.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.details.open
-spec_url: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-open
+specifications: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-details-open
 ---
 
 # `open`

--- a/content/html/reference/elements/details/details.md
+++ b/content/html/reference/elements/details/details.md
@@ -2,7 +2,7 @@
 title: '<details>: The Details disclosure element'
 short_title: <details>
 mdn_url: /en-US/docs/Web/HTML/Element/details
-spec_url: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
+specifications: https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element
 tags:
     group: Interactive elements
 api: HTMLDetailsElement

--- a/content/html/reference/elements/dfn/dfn.md
+++ b/content/html/reference/elements/dfn/dfn.md
@@ -2,7 +2,7 @@
 title: '<dfn>: The Definition element'
 short_title: <dfn>
 mdn_url: /en-US/docs/Web/HTML/Element/dfn
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-dfn-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-dfn-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/dialog/attributes/open.md
+++ b/content/html/reference/elements/dialog/attributes/open.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.dialog.open
-spec_url: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open
+specifications: https://html.spec.whatwg.org/multipage/interactive-elements.html#attr-dialog-open
 ---
 
 # `open`

--- a/content/html/reference/elements/dialog/dialog.md
+++ b/content/html/reference/elements/dialog/dialog.md
@@ -2,7 +2,7 @@
 title: '<dialog>: The Dialog element'
 short_title: <dialog>
 mdn_url: /en-US/docs/Web/HTML/Element/dialog
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#the-dialog-element
+specifications: https://html.spec.whatwg.org/multipage/forms.html#the-dialog-element
 tags:
     group: Interactive elements
 api: HTMLDialogElement

--- a/content/html/reference/elements/div/div.md
+++ b/content/html/reference/elements/div/div.md
@@ -2,7 +2,7 @@
 title: '<div>: The Content Division element'
 short_title: <div>
 mdn_url: /en-US/docs/Web/HTML/Element/div
-spec_url: https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element
+specifications: https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element
 tags:
     group: Text content
 api: HTMLDivElement

--- a/content/html/reference/elements/dl/dl.md
+++ b/content/html/reference/elements/dl/dl.md
@@ -2,7 +2,7 @@
 title: '<dl>: The Description List element'
 short_title: <dl>
 mdn_url: /en-US/docs/Web/HTML/Element/dl
-spec_url: https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
+specifications: https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element
 tags:
     group: Text content
 api: HTMLDListElement

--- a/content/html/reference/elements/dt/dt.md
+++ b/content/html/reference/elements/dt/dt.md
@@ -2,7 +2,7 @@
 title: '<dt>: The Description Term element'
 short_title: <dt>
 mdn_url: /en-US/docs/Web/HTML/Element/dt
-spec_url: https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element
+specifications: https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/em/em.md
+++ b/content/html/reference/elements/em/em.md
@@ -2,7 +2,7 @@
 title: '<em>: The Emphasis element'
 short_title: <em>
 mdn_url: /en-US/docs/Web/HTML/Element/em
-spec_url: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element
+specifications: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/embed/attributes/height.md
+++ b/content/html/reference/elements/embed/attributes/height.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.embed.height
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
 ---
 
 # `height`

--- a/content/html/reference/elements/embed/attributes/src.md
+++ b/content/html/reference/elements/embed/attributes/src.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.embed.src
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src
 ---
 
 # `src`

--- a/content/html/reference/elements/embed/attributes/type.md
+++ b/content/html/reference/elements/embed/attributes/type.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.embed.type
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-type
 ---
 
 # `type`

--- a/content/html/reference/elements/embed/attributes/width.md
+++ b/content/html/reference/elements/embed/attributes/width.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.embed.width
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
 ---
 
 # `width`

--- a/content/html/reference/elements/embed/embed.md
+++ b/content/html/reference/elements/embed/embed.md
@@ -2,7 +2,7 @@
 title: '<embed>: The Embed External Content element'
 short_title: <embed>
 mdn_url: /en-US/docs/Web/HTML/Element/embed
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element
 tags:
     group: Embedded content
 api: HTMLEmbedElement

--- a/content/html/reference/elements/fieldset/attributes/disabled.md
+++ b/content/html/reference/elements/fieldset/attributes/disabled.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.fieldset.disabled
-spec_url: https://html.spec.whatwg.org/multipage/form-elements.html#attr-fieldset-disabled
+specifications: https://html.spec.whatwg.org/multipage/form-elements.html#attr-fieldset-disabled
 ---
 
 # `disabled`

--- a/content/html/reference/elements/fieldset/attributes/form.md
+++ b/content/html/reference/elements/fieldset/attributes/form.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.fieldset.form
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
 ---
 
 # `form`

--- a/content/html/reference/elements/fieldset/attributes/name.md
+++ b/content/html/reference/elements/fieldset/attributes/name.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.fieldset.name
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
 ---
 
 # `name`

--- a/content/html/reference/elements/fieldset/fieldset.md
+++ b/content/html/reference/elements/fieldset/fieldset.md
@@ -2,7 +2,7 @@
 title: '<fieldset>: The Field Set element'
 short_title: <fieldset>
 mdn_url: /en-US/docs/Web/HTML/Element/fieldset
-spec_url: https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element
+specifications: https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element
 tags:
     group: Forms
 api: HTMLFieldSetElement

--- a/content/html/reference/elements/figcaption/figcaption.md
+++ b/content/html/reference/elements/figcaption/figcaption.md
@@ -2,7 +2,7 @@
 title: '<figcaption>'
 short_title: <figcaption>
 mdn_url: /en-US/docs/Web/HTML/Element/figcaption
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-figcaption-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-figcaption-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/figure/figure.md
+++ b/content/html/reference/elements/figure/figure.md
@@ -2,7 +2,7 @@
 title: '<figure>'
 short_title: <figure>
 mdn_url: /en-US/docs/Web/HTML/Element/figure
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-figure-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-figure-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/footer/footer.md
+++ b/content/html/reference/elements/footer/footer.md
@@ -1,7 +1,7 @@
 ---
 title: '<footer>'
 mdn_url: /en-US/docs/Web/HTML/Element/footer
-spec_url: https://html.spec.whatwg.org/multipage/semantics#the-footer-element
+specifications: https://html.spec.whatwg.org/multipage/semantics#the-footer-element
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/form/attributes/accept-charset.md
+++ b/content/html/reference/elements/form/attributes/accept-charset.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.accept-charset
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#attr-form-accept-charset
+specifications: https://html.spec.whatwg.org/multipage/forms.html#attr-form-accept-charset
 ---
 
 # `accept-charset`

--- a/content/html/reference/elements/form/attributes/action.md
+++ b/content/html/reference/elements/form/attributes/action.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.action
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action
 ---
 
 # `action`

--- a/content/html/reference/elements/form/attributes/autocapitalize.md
+++ b/content/html/reference/elements/form/attributes/autocapitalize.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.autocapitalize
-spec_url: non-standard
+specifications: non-standard
 ---
 
 # `autocapitalize`

--- a/content/html/reference/elements/form/attributes/autocomplete.md
+++ b/content/html/reference/elements/form/attributes/autocomplete.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.autocomplete
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#attr-form-autocomplete
+specifications: https://html.spec.whatwg.org/multipage/forms.html#attr-form-autocomplete
 ---
 
 # `autocomplete`

--- a/content/html/reference/elements/form/attributes/enctype.md
+++ b/content/html/reference/elements/form/attributes/enctype.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.enctype
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype
 ---
 
 # `enctype`

--- a/content/html/reference/elements/form/attributes/method.md
+++ b/content/html/reference/elements/form/attributes/method.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.method
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
 ---
 
 # `method`

--- a/content/html/reference/elements/form/attributes/name.md
+++ b/content/html/reference/elements/form/attributes/name.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.name
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#attr-form-name
+specifications: https://html.spec.whatwg.org/multipage/forms.html#attr-form-name
 ---
 
 # `name`

--- a/content/html/reference/elements/form/attributes/novalidate.md
+++ b/content/html/reference/elements/form/attributes/novalidate.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.novalidate
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-novalidate
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-novalidate
 ---
 
 # `novalidate`

--- a/content/html/reference/elements/form/attributes/target.md
+++ b/content/html/reference/elements/form/attributes/target.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.form.target
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-target
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-target
 ---
 
 # `target`

--- a/content/html/reference/elements/form/form.md
+++ b/content/html/reference/elements/form/form.md
@@ -1,7 +1,7 @@
 ---
 title: '<form>'
 mdn_url: /en-US/docs/Web/HTML/Element/form
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#the-form-element
+specifications: https://html.spec.whatwg.org/multipage/forms.html#the-form-element
 tags:
     group: Forms
 api: HTMLFormElement

--- a/content/html/reference/elements/h1-h6/h1-h6.md
+++ b/content/html/reference/elements/h1-h6/h1-h6.md
@@ -2,7 +2,7 @@
 title: '<h1>–<h6>: The HTML Section Heading elements'
 short_title: <h1>-<h6>
 mdn_url: /en-US/docs/Web/HTML/Element/Heading_Elements
-spec_url: https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
+specifications: https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements
 tags:
     group: Content sectioning
 api: HTMLHeadingElement

--- a/content/html/reference/elements/head/head.md
+++ b/content/html/reference/elements/head/head.md
@@ -2,7 +2,7 @@
 title: '<head>: The Document Metadata (Header) element'
 short_title: <head>
 mdn_url: /en-US/docs/Web/HTML/Element/head
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-head-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-head-element
 tags:
     group: Document metadata
 api: HTMLHeadElement

--- a/content/html/reference/elements/header/header.md
+++ b/content/html/reference/elements/header/header.md
@@ -1,7 +1,7 @@
 ---
 title: '<header>'
 mdn_url: /en-US/docs/Web/HTML/Element/header
-spec_url: https://html.spec.whatwg.org/multipage/sections.html#the-header-element
+specifications: https://html.spec.whatwg.org/multipage/sections.html#the-header-element
 tags:
     group: Content sectioning
 api: HTMLElement

--- a/content/html/reference/elements/hr/hr.md
+++ b/content/html/reference/elements/hr/hr.md
@@ -2,7 +2,7 @@
 title: '<hr>: The Thematic Break (Horizontal Rule) element'
 short_title: <hr>
 mdn_url: /en-US/docs/Web/HTML/Element/hr
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-hr-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-hr-element
 tags:
     group: Text content
 api: HTMLElement

--- a/content/html/reference/elements/html/attributes/xmlns.md
+++ b/content/html/reference/elements/html/attributes/xmlns.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.html.xmlns
-spec_url: https://html.spec.whatwg.org/#attributes-2:xmlns-namespace
+specifications: https://html.spec.whatwg.org/#attributes-2:xmlns-namespace
 ---
 
 # `xmlns`

--- a/content/html/reference/elements/html/html.md
+++ b/content/html/reference/elements/html/html.md
@@ -2,7 +2,7 @@
 title: '<html>: The HTML Document / Root element'
 short_title: <html>
 mdn_url: /en-US/docs/Web/HTML/Element/html
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-html-element
 tags:
     group: Main root
 api: HTMLHtmlElement

--- a/content/html/reference/elements/i/i.md
+++ b/content/html/reference/elements/i/i.md
@@ -1,7 +1,7 @@
 ---
 title: '<i>'
 mdn_url: /en-US/docs/Web/HTML/Element/i
-spec_url: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element
+specifications: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/iframe/attributes/align.md
+++ b/content/html/reference/elements/iframe/attributes/align.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.align
-spec_url: https://html.spec.whatwg.org/#attr-iframe-align
+specifications: https://html.spec.whatwg.org/#attr-iframe-align
 ---
 
 # `align`

--- a/content/html/reference/elements/iframe/attributes/allow.md
+++ b/content/html/reference/elements/iframe/attributes/allow.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.allow
-spec_url:
+specifications:
  - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow
  - https://w3c.github.io/webappsec-feature-policy/#iframe-allow-attribute
 ---

--- a/content/html/reference/elements/iframe/attributes/allowfullscreen.md
+++ b/content/html/reference/elements/iframe/attributes/allowfullscreen.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.allowfullscreen
-spec_url:
+specifications:
   - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen
   - https://w3c.github.io/webappsec-feature-policy/#iframe-allowfullscreen-attribute
 ---

--- a/content/html/reference/elements/iframe/attributes/allowpaymentrequest.md
+++ b/content/html/reference/elements/iframe/attributes/allowpaymentrequest.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.allowpaymentrequest
-spec_url:
+specifications:
   - https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowpaymentrequest
   - https://w3c.github.io/webappsec-feature-policy/#iframe-allowpaymentrequest-attribute
 ---

--- a/content/html/reference/elements/iframe/attributes/csp.md
+++ b/content/html/reference/elements/iframe/attributes/csp.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.csp
-spec_url: https://w3c.github.io/webappsec-cspee/#element-attrdef-iframe-csp
+specifications: https://w3c.github.io/webappsec-cspee/#element-attrdef-iframe-csp
 ---
 
 # `csp`

--- a/content/html/reference/elements/iframe/attributes/frameborder.md
+++ b/content/html/reference/elements/iframe/attributes/frameborder.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.frameborder
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-iframe-frameborder
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-iframe-frameborder
 ---
 
 # `frameborder`

--- a/content/html/reference/elements/iframe/attributes/height.md
+++ b/content/html/reference/elements/iframe/attributes/height.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.height
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
 ---
 
 # `height`

--- a/content/html/reference/elements/iframe/attributes/importance.md
+++ b/content/html/reference/elements/iframe/attributes/importance.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.importance
-spec_url: https://wicg.github.io/priority-hints/#solution-0
+specifications: https://wicg.github.io/priority-hints/#solution-0
 ---
 
 # `importance`

--- a/content/html/reference/elements/iframe/attributes/longdesc.md
+++ b/content/html/reference/elements/iframe/attributes/longdesc.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.longdesc
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-longdesc
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-longdesc
 ---
 
 # `longdesc`

--- a/content/html/reference/elements/iframe/attributes/marginheight.md
+++ b/content/html/reference/elements/iframe/attributes/marginheight.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.marginheight
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-marginheight
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-marginheight
 ---
 
 # `marginheight`

--- a/content/html/reference/elements/iframe/attributes/marginwidth.md
+++ b/content/html/reference/elements/iframe/attributes/marginwidth.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.marginwidth
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-marginwidth
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#dom-iframe-marginwidth
 ---
 
 # `marginwidth`

--- a/content/html/reference/elements/iframe/attributes/name.md
+++ b/content/html/reference/elements/iframe/attributes/name.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.name
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name
 ---
 
 # `name`

--- a/content/html/reference/elements/iframe/attributes/referrerpolicy.md
+++ b/content/html/reference/elements/iframe/attributes/referrerpolicy.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.referrerpolicy
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-referrerpolicy
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-referrerpolicy
 ---
 
 # `referrerpolicy`

--- a/content/html/reference/elements/iframe/attributes/sandbox.md
+++ b/content/html/reference/elements/iframe/attributes/sandbox.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.sandbox
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
 ---
 
 # `sandbox`

--- a/content/html/reference/elements/iframe/attributes/scrolling.md
+++ b/content/html/reference/elements/iframe/attributes/scrolling.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.scrolling
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-iframe-scrolling
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-iframe-scrolling
 ---
 
 # `scrolling`

--- a/content/html/reference/elements/iframe/attributes/src.md
+++ b/content/html/reference/elements/iframe/attributes/src.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.src
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src
 ---
 
 # `src`

--- a/content/html/reference/elements/iframe/attributes/srcdoc.md
+++ b/content/html/reference/elements/iframe/attributes/srcdoc.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.srcdoc
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc
 ---
 
 # `srcdoc`

--- a/content/html/reference/elements/iframe/attributes/width.md
+++ b/content/html/reference/elements/iframe/attributes/width.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.iframe.width
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
 ---
 
 # `width`

--- a/content/html/reference/elements/iframe/iframe.md
+++ b/content/html/reference/elements/iframe/iframe.md
@@ -2,7 +2,7 @@
 title: '<iframe>: The Inline Frame element'
 short_title: <iframe>
 mdn_url: /en-US/docs/Web/HTML/Element/iframe
-spec_url: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
+specifications: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element
 tags:
     group: Embedded content
 api: HTMLIFrameElement

--- a/content/html/reference/elements/input-button/input-button.md
+++ b/content/html/reference/elements/input-button/input-button.md
@@ -1,7 +1,7 @@
 ---
 title: '<input type="button">'
 mdn_url: /en-US/docs/Web/HTML/Element/input/button
-spec_url: https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
+specifications: https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)
 interactive_example:
     url: https://interactive-examples.mdn.mozilla.net/pages/tabbed/input-button.html
     height: html-short

--- a/content/html/reference/elements/input-checkbox/input-checkbox.md
+++ b/content/html/reference/elements/input-checkbox/input-checkbox.md
@@ -1,7 +1,7 @@
 ---
 title: '<input type="checkbox">'
 mdn_url: /en-US/docs/Web/HTML/Element/input/checkbox
-spec_url: https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)
+specifications: https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)
 interactive_example:
     url: https://interactive-examples.mdn.mozilla.net/pages/tabbed/input-checkbox.html
     height: html-standard

--- a/content/html/reference/elements/input/attributes/autofocus.md
+++ b/content/html/reference/elements/input/attributes/autofocus.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/interaction.html#attr-fe-autofocus
+specifications: https://html.spec.whatwg.org/multipage/interaction.html#attr-fe-autofocus
 ---
 # `autofocus`
 

--- a/content/html/reference/elements/input/attributes/checked.md
+++ b/content/html/reference/elements/input/attributes/checked.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-checked
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-checked
 ---
 # `checked`
 

--- a/content/html/reference/elements/input/attributes/disabled.md
+++ b/content/html/reference/elements/input/attributes/disabled.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
 ---
 # `disabled`
 

--- a/content/html/reference/elements/input/attributes/form.md
+++ b/content/html/reference/elements/input/attributes/form.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form
 ---
 # `form`
 

--- a/content/html/reference/elements/input/attributes/name.md
+++ b/content/html/reference/elements/input/attributes/name.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
+specifications: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name
 ---
 # `name`
 

--- a/content/html/reference/elements/input/attributes/readonly-checkbox.md
+++ b/content/html/reference/elements/input/attributes/readonly-checkbox.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
 ---
 # `readonly`
 

--- a/content/html/reference/elements/input/attributes/readonly.md
+++ b/content/html/reference/elements/input/attributes/readonly.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
 ---
 # `readonly`
 

--- a/content/html/reference/elements/input/attributes/required.md
+++ b/content/html/reference/elements/input/attributes/required.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-required
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-required
 ---
 # `required`
 

--- a/content/html/reference/elements/input/attributes/type.md
+++ b/content/html/reference/elements/input/attributes/type.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-type
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-type
 ---
 # `type`
 

--- a/content/html/reference/elements/input/attributes/value-checkbox.md
+++ b/content/html/reference/elements/input/attributes/value-checkbox.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-value
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-value
 ---
 # `value`
 

--- a/content/html/reference/elements/input/attributes/value.md
+++ b/content/html/reference/elements/input/attributes/value.md
@@ -1,5 +1,5 @@
 ---
-spec_url: https://html.spec.whatwg.org/multipage/input.html#attr-input-value
+specifications: https://html.spec.whatwg.org/multipage/input.html#attr-input-value
 ---
 # `value`
 

--- a/content/html/reference/elements/input/input.md
+++ b/content/html/reference/elements/input/input.md
@@ -2,7 +2,7 @@
 title: '<input>: The Input (Form Input) element'
 short_title: <input>
 mdn_url: /en-US/docs/Web/HTML/Element/input
-spec_url: https://html.spec.whatwg.org/multipage/input.html#the-input-element
+specifications: https://html.spec.whatwg.org/multipage/input.html#the-input-element
 interactive_example:
     url: https://interactive-examples.mdn.mozilla.net/pages/tabbed/input-text.html
     height: html-short

--- a/content/html/reference/elements/ins/attributes/cite.md
+++ b/content/html/reference/elements/ins/attributes/cite.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.ins.cite
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-cite
+specifications: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-cite
 ---
 
 # `cite`

--- a/content/html/reference/elements/ins/attributes/datetime.md
+++ b/content/html/reference/elements/ins/attributes/datetime.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.ins.datetime
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-datetime
+specifications: https://html.spec.whatwg.org/multipage/edits.html#attr-mod-datetime
 ---
 
 # `datetime`

--- a/content/html/reference/elements/ins/ins.md
+++ b/content/html/reference/elements/ins/ins.md
@@ -1,7 +1,7 @@
 ---
 title: '<ins>'
 mdn_url: /en-US/docs/Web/HTML/Element/ins
-spec_url: https://html.spec.whatwg.org/multipage/edits.html#the-ins-element
+specifications: https://html.spec.whatwg.org/multipage/edits.html#the-ins-element
 tags:
     group: Inline text semantics
 api: HTMLModElement

--- a/content/html/reference/elements/kbd/kbd.md
+++ b/content/html/reference/elements/kbd/kbd.md
@@ -2,7 +2,7 @@
 title: '<kbd>: The Keyboard Input element'
 short_title: <kbd>
 mdn_url: /en-US/docs/Web/HTML/Element/kbd
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-kbd-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-kbd-element
 tags:
     group: Inline text semantics
 api: HTMLElement

--- a/content/html/reference/elements/label/attributes/for.md
+++ b/content/html/reference/elements/label/attributes/for.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.label.for
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#attr-label-for
+specifications: https://html.spec.whatwg.org/multipage/forms.html#attr-label-for
 ---
 
 # `for`

--- a/content/html/reference/elements/label/label.md
+++ b/content/html/reference/elements/label/label.md
@@ -1,7 +1,7 @@
 ---
 title: '<label>'
 mdn_url: /en-US/docs/Web/HTML/Element/label
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#the-label-element
+specifications: https://html.spec.whatwg.org/multipage/forms.html#the-label-element
 tags:
     group: Forms
 api: HTMLLabelElement

--- a/content/html/reference/elements/legend/legend.md
+++ b/content/html/reference/elements/legend/legend.md
@@ -1,7 +1,7 @@
 ---
 title: '<legend>'
 mdn_url: /en-US/docs/Web/HTML/Element/legend
-spec_url: https://html.spec.whatwg.org/multipage/forms.html#the-legend-element
+specifications: https://html.spec.whatwg.org/multipage/forms.html#the-legend-element
 tags:
     group: Forms
 api: HTMLLegendElement

--- a/content/html/reference/elements/li/attributes/value.md
+++ b/content/html/reference/elements/li/attributes/value.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.li.value
-spec_url: https://html.spec.whatwg.org/multipage/grouping-content.html#attr-li-value
+specifications: https://html.spec.whatwg.org/multipage/grouping-content.html#attr-li-value
 ---
 
 # `value`

--- a/content/html/reference/elements/li/li.md
+++ b/content/html/reference/elements/li/li.md
@@ -1,7 +1,7 @@
 ---
 title: '<li>'
 mdn_url: /en-US/docs/Web/HTML/Element/li
-spec_url: https://html.spec.whatwg.org/multipage/semantics.html#the-li-element
+specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-li-element
 tags:
     group: Text content
 api: HTMLLIElement

--- a/content/html/reference/elements/table/attributes/align.md
+++ b/content/html/reference/elements/table/attributes/align.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.align
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-align
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-align
 ---
 
 # `align`

--- a/content/html/reference/elements/table/attributes/bgcolor.md
+++ b/content/html/reference/elements/table/attributes/bgcolor.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.bgcolor
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-bgcolor
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-bgcolor
 ---
 
 # `bgcolor`

--- a/content/html/reference/elements/table/attributes/border.md
+++ b/content/html/reference/elements/table/attributes/border.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.border
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-border
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-border
 ---
 
 # `border`

--- a/content/html/reference/elements/table/attributes/cellpadding.md
+++ b/content/html/reference/elements/table/attributes/cellpadding.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.cellpadding
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-cellpadding
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-cellpadding
 ---
 
 # `cellpadding`

--- a/content/html/reference/elements/table/attributes/cellspacing.md
+++ b/content/html/reference/elements/table/attributes/cellspacing.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.cellspacing
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-cellspacing
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-cellspacing
 ---
 
 # `cellspacing`

--- a/content/html/reference/elements/table/attributes/frame.md
+++ b/content/html/reference/elements/table/attributes/frame.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.frame
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-frame
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-frame
 ---
 
 # `frame`

--- a/content/html/reference/elements/table/attributes/rules.md
+++ b/content/html/reference/elements/table/attributes/rules.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.rules
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-rules
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-rules
 ---
 
 # `rules`

--- a/content/html/reference/elements/table/attributes/summary.md
+++ b/content/html/reference/elements/table/attributes/summary.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.summary
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-summary
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-summary
 ---
 
 # `summary`

--- a/content/html/reference/elements/table/attributes/width.md
+++ b/content/html/reference/elements/table/attributes/width.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.table.width
-spec_url: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-width
+specifications: https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-width
 ---
 
 # `width`

--- a/content/html/reference/elements/table/table.md
+++ b/content/html/reference/elements/table/table.md
@@ -2,7 +2,7 @@
 title: '<table>: The Table element'
 short_title: <table>
 mdn_url: /en-US/docs/Web/HTML/Element/table
-spec_url: https://html.spec.whatwg.org/multipage/tables.html#the-table-element
+specifications: https://html.spec.whatwg.org/multipage/tables.html#the-table-element
 tags:
     group: Flow content
 api: HTMLTableElement

--- a/content/html/reference/elements/video/attributes/autoplay.md
+++ b/content/html/reference/elements/video/attributes/autoplay.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.autoplay
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay
 ---
 
 # `autoplay`

--- a/content/html/reference/elements/video/attributes/controls.md
+++ b/content/html/reference/elements/video/attributes/controls.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.controls
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-controls
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-controls
 ---
 
 # `controls`

--- a/content/html/reference/elements/video/attributes/crossorigin.md
+++ b/content/html/reference/elements/video/attributes/crossorigin.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.crossorigin
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
 ---
 
 # `crossorigin`

--- a/content/html/reference/elements/video/attributes/height.md
+++ b/content/html/reference/elements/video/attributes/height.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.height
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-height
 ---
 
 # `height`

--- a/content/html/reference/elements/video/attributes/loop.md
+++ b/content/html/reference/elements/video/attributes/loop.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.loop
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-loop
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-loop
 ---
 
 # `loop`

--- a/content/html/reference/elements/video/attributes/muted.md
+++ b/content/html/reference/elements/video/attributes/muted.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.muted
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-muted
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-muted
 ---
 
 # `muted`

--- a/content/html/reference/elements/video/attributes/playsinline.md
+++ b/content/html/reference/elements/video/attributes/playsinline.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.playsinline
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-video-playsinline
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-video-playsinline
 ---
 
 # `playsinline`

--- a/content/html/reference/elements/video/attributes/poster.md
+++ b/content/html/reference/elements/video/attributes/poster.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.poster
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-video-poster
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-video-poster
 ---
 
 # `poster`

--- a/content/html/reference/elements/video/attributes/preload.md
+++ b/content/html/reference/elements/video/attributes/preload.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.preload
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
 ---
 
 # `preload`

--- a/content/html/reference/elements/video/attributes/src.md
+++ b/content/html/reference/elements/video/attributes/src.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.src
-spec_url: https://html.spec.whatwg.org/multipage/media.html#attr-media-src
+specifications: https://html.spec.whatwg.org/multipage/media.html#attr-media-src
 ---
 
 # `src`

--- a/content/html/reference/elements/video/attributes/width.md
+++ b/content/html/reference/elements/video/attributes/width.md
@@ -1,6 +1,6 @@
 ---
 browser-compatibility: html.elements.video.width
-spec_url: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
+specifications: https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width
 ---
 
 # `width`

--- a/content/html/reference/elements/video/video.md
+++ b/content/html/reference/elements/video/video.md
@@ -2,7 +2,7 @@
 title: '<video>: The Video Embed element'
 short_title: <video>
 mdn_url: /en-US/docs/Web/HTML/Element/video
-spec_url: https://html.spec.whatwg.org/multipage/media.html#the-video-element
+specifications: https://html.spec.whatwg.org/multipage/media.html#the-video-element
 tags:
     group: Image and multimedia
 api: HTMLVideoElement

--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -13,5 +13,6 @@ body:
     - meta.animatable
     - meta.initial-value
     - meta.shorthand-for
+- meta.specifications
 - meta.browser-compatibility
 - prose.see-also

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -10,5 +10,6 @@ body:
 - prose.*
 - meta.examples
 - meta.info_box
+- meta.specifications
 - meta.browser_compatibility
 - prose.see_also

--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -12,5 +12,6 @@ body:
 - prose.*
 - meta.examples
 - meta.info_box
+- meta.specifications
 - meta.browser_compatibility
 - prose.see_also

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -5,6 +5,7 @@ const matter = require('gray-matter');
 
 const { packageContributors } = require('./resolve-contributors');
 const related = require('./related-content');
+const specifications = require('./build-specs');
 const guidePage = require('./build-guide-page-json');
 const landingPage = require('./build-landing-page-json');
 const recipePage = require('./build-recipe-page-json');
@@ -77,6 +78,7 @@ async function buildPageJSON(docsPath) {
         const item = {
           title: data.title,
           mdn_url: data.mdn_url,
+          specifications: specifications.buildSpecs(data.spec_url),
           related_content: await related.buildRelatedContent(relatedContentSpec),
           body: body,
           contributors: contributors

--- a/scripts/build-json/build-page-json.js
+++ b/scripts/build-json/build-page-json.js
@@ -5,7 +5,6 @@ const matter = require('gray-matter');
 
 const { packageContributors } = require('./resolve-contributors');
 const related = require('./related-content');
-const specifications = require('./build-specs');
 const guidePage = require('./build-guide-page-json');
 const landingPage = require('./build-landing-page-json');
 const recipePage = require('./build-recipe-page-json');
@@ -78,7 +77,6 @@ async function buildPageJSON(docsPath) {
         const item = {
           title: data.title,
           mdn_url: data.mdn_url,
-          specifications: specifications.buildSpecs(data.spec_url),
           related_content: await related.buildRelatedContent(relatedContentSpec),
           body: body,
           contributors: contributors

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -5,6 +5,7 @@ const { packageExamples } = require('./compose-examples');
 const { packageAttributes } = require('./compose-attributes');
 const { packageInteractiveExample } = require('./compose-interactive-example');
 const { packageProse } = require('./slice-prose');
+const { packageSpecs } = require('./build-specs');
 
 async function processMetaIngredient(elementPath, ingredientName, data) {
     switch (ingredientName) {
@@ -14,6 +15,12 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
                 return null;
             }
             return packageInteractiveExample(data.interactive_example);
+        case 'specifications':
+            // spec_url is optional
+            if (!data.spec_url) {
+                return null;
+            }
+            return packageSpecs(data.spec_url);
         case 'browser_compatibility':
             return {query: data.browser_compatibility, data: packageBCD(data.browser_compatibility)};
         case 'attributes':

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -16,11 +16,11 @@ async function processMetaIngredient(elementPath, ingredientName, data) {
             }
             return packageInteractiveExample(data.interactive_example);
         case 'specifications':
-            // spec_url is optional
-            if (!data.spec_url) {
+            // specifications is optional
+            if (!data.specifications) {
                 return null;
             }
-            return packageSpecs(data.spec_url);
+            return packageSpecs(data.specifications);
         case 'browser_compatibility':
             return {query: data.browser_compatibility, data: packageBCD(data.browser_compatibility)};
         case 'attributes':

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-
+const yaml = require('js-yaml');
 const { ROOT } = require('./constants');
 
 function packageSpecs(specUrls) {
@@ -11,8 +11,7 @@ function packageSpecs(specUrls) {
   }
 
   const dataDir = path.resolve(ROOT, 'content', 'data');
-  const file = fs.readFileSync(path.join(dataDir, 'specifications.json'), 'utf8');
-  const specMap = JSON.parse(file);
+  const specMap = yaml.safeLoad(fs.readFileSync(path.join(dataDir, 'specifications.yaml'), 'utf8'));
 
   function findTitle(specUrl) {
     let title = ''

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -21,7 +21,7 @@ function packageSpecs(specifications) {
       }
     });
     if (title === '') {
-      throw new Error(`Domain for "${specification}" not found in data/specifications.json`);
+      throw new Error(`Domain for "${specification}" not found in data/specifications.yaml`);
     }
     return title;
   }

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+const { ROOT } = require('./constants');
+
+function buildSpecs(specUrls) {
+
+  // spec_url is optional, return nothing so there is no specifications property
+  if (!specUrls) {
+    return;
+  }
+  // spec_url can be just "non-standard", route it through in that case
+  if (specUrls === 'non-standard') {
+    return specUrls;
+  }
+
+  const dataDir = path.resolve(ROOT, 'content', 'data');
+  const file = fs.readFileSync(dataDir + '/specifications.json', 'utf8');
+  const specMap = JSON.parse(file);
+
+  function findTitle(specUrl) {
+    let title = ''
+    Object.entries(specMap).forEach(([key, value]) => {
+      if (specUrl.includes(key)) {
+        title = value;
+      }
+    });
+    if (title === '') {
+      console.error(`Domain for "${specUrl}" not found in data/specifications.json`);
+    }
+    return title;
+  }
+
+  // For authoring convenience, you can provide one or more specs
+  if (!Array.isArray(specUrls)) {
+    specUrls = [specUrls];
+  }
+
+  let specifications = [];
+  specUrls.forEach(specUrl => {
+    specifications.push({
+      url: specUrl,
+      title: findTitle(specUrl)
+    });
+  });
+
+  return specifications;
+}
+
+module.exports = {
+  buildSpecs
+}

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -11,7 +11,7 @@ function packageSpecs(specUrls) {
   }
 
   const dataDir = path.resolve(ROOT, 'content', 'data');
-  const file = fs.readFileSync(dataDir + '/specifications.json', 'utf8');
+  const file = fs.readFileSync(path.join(dataDir, 'specifications.json'), 'utf8');
   const specMap = JSON.parse(file);
 
   function findTitle(specUrl) {
@@ -22,7 +22,7 @@ function packageSpecs(specUrls) {
       }
     });
     if (title === '') {
-      console.error(`Domain for "${specUrl}" not found in data/specifications.json`);
+      throw new Error(`Domain for "${specUrl}" not found in data/specifications.json`);
     }
     return title;
   }

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -3,43 +3,43 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { ROOT } = require('./constants');
 
-function packageSpecs(specUrls) {
+function packageSpecs(specifications) {
 
-  // spec_url can be just "non-standard", route it through in that case
-  if (specUrls === 'non-standard') {
-    return specUrls;
+  // specifications can be just "non-standard", route it through in that case
+  if (specifications === 'non-standard') {
+    return specifications;
   }
 
   const dataDir = path.resolve(ROOT, 'content', 'data');
   const specMap = yaml.safeLoad(fs.readFileSync(path.join(dataDir, 'specifications.yaml'), 'utf8'));
 
-  function findTitle(specUrl) {
+  function findTitle(specification) {
     let title = ''
     Object.entries(specMap).forEach(([key, value]) => {
-      if (specUrl.includes(key)) {
+      if (specification.includes(key)) {
         title = value;
       }
     });
     if (title === '') {
-      throw new Error(`Domain for "${specUrl}" not found in data/specifications.json`);
+      throw new Error(`Domain for "${specification}" not found in data/specifications.json`);
     }
     return title;
   }
 
   // For authoring convenience, you can provide one or more specs
-  if (!Array.isArray(specUrls)) {
-    specUrls = [specUrls];
+  if (!Array.isArray(specifications)) {
+    specifications = [specifications];
   }
 
-  let specifications = [];
-  specUrls.forEach(specUrl => {
-    specifications.push({
-      url: specUrl,
-      title: findTitle(specUrl)
+  let packageSpecs = [];
+  specifications.forEach(specification => {
+    packageSpecs.push({
+      url: specification,
+      title: findTitle(specification)
     });
   });
 
-  return specifications;
+  return packageSpecs;
 }
 
 module.exports = {

--- a/scripts/build-json/build-specs.js
+++ b/scripts/build-json/build-specs.js
@@ -3,12 +3,8 @@ const path = require('path');
 
 const { ROOT } = require('./constants');
 
-function buildSpecs(specUrls) {
+function packageSpecs(specUrls) {
 
-  // spec_url is optional, return nothing so there is no specifications property
-  if (!specUrls) {
-    return;
-  }
   // spec_url can be just "non-standard", route it through in that case
   if (specUrls === 'non-standard') {
     return specUrls;
@@ -48,5 +44,5 @@ function buildSpecs(specUrls) {
 }
 
 module.exports = {
-  buildSpecs
+  packageSpecs
 }

--- a/scripts/build-json/compose-attributes.js
+++ b/scripts/build-json/compose-attributes.js
@@ -7,6 +7,8 @@ const jsdom = require('jsdom');
 
 const { JSDOM } = jsdom;
 
+const specifications = require('./build-specs');
+
 function extractFromSiblings(node, terminatorTags, contentType) {
     let content = '';
     let sib = node.nextSibling;
@@ -38,7 +40,7 @@ function packageValues(dom) {
 
 async function packageAttribute(attributePath) {
     const attributeMD = fs.readFileSync(attributePath, 'utf8');
-    const {content} = matter(attributeMD);
+    const {data, content} = matter(attributeMD);
     const contentHTML = await markdown.markdownToHTML(content);
     const dom = JSDOM.fragment(contentHTML);
     const attribute = {};
@@ -58,6 +60,9 @@ async function packageAttribute(attributePath) {
     if (h2Headings.length === 2) {
         attribute.values = packageValues(dom);
     }
+
+    // extract the specifications
+    attribute.specifications = specifications.buildSpecs(data.spec_url);
 
     return attribute;
 }

--- a/scripts/build-json/compose-attributes.js
+++ b/scripts/build-json/compose-attributes.js
@@ -7,8 +7,6 @@ const jsdom = require('jsdom');
 
 const { JSDOM } = jsdom;
 
-const specifications = require('./build-specs');
-
 function extractFromSiblings(node, terminatorTags, contentType) {
     let content = '';
     let sib = node.nextSibling;
@@ -40,7 +38,7 @@ function packageValues(dom) {
 
 async function packageAttribute(attributePath) {
     const attributeMD = fs.readFileSync(attributePath, 'utf8');
-    const {data, content} = matter(attributeMD);
+    const {content} = matter(attributeMD);
     const contentHTML = await markdown.markdownToHTML(content);
     const dom = JSDOM.fragment(contentHTML);
     const attribute = {};
@@ -60,9 +58,6 @@ async function packageAttribute(attributePath) {
     if (h2Headings.length === 2) {
         attribute.values = packageValues(dom);
     }
-
-    // extract the specifications
-    attribute.specifications = specifications.buildSpecs(data.spec_url);
 
     return attribute;
 }


### PR DESCRIPTION
This is the next part for https://github.com/mdn/stumptown-content/issues/126.

It does these things: 
- adds a `data/specifications.json` file containing allowed specs with their titles.
- exposes a new `specifications` property to the packaged JSON of pages and HTML attributes.

I wonder if we want `data/specifications.yaml` instead. It would allow us to comment on our spec choices.