### PR TITLE
Preserve language information for pre blocks

### DIFF
--- a/scripts/scraper/code.js
+++ b/scripts/scraper/code.js
@@ -1,0 +1,34 @@
+'use strict'
+
+module.exports = code
+
+const is = require('hast-util-is-element');
+const has = require('hast-util-has-property');
+const toText = require('hast-util-to-text');
+const trim = require('trim-trailing-lines');
+
+/**
+ * An alternative version of the built-in handler for
+ * converting `pre` blocks from HTML to Markdown.
+ *
+ * The built-in version, in hast-util-to-mdast,
+ * sets `lang` based on classes like "language-html".
+ *
+ * But in MDN code blocks use "brush: html" to indicate
+ * language. So this handler looks for that instead.
+ */
+
+function code(h, node) {
+  let lang;
+
+  if (node.tagName === 'pre') {
+    if (has(node, 'className')) {
+      let brushIndex = node.properties.className.indexOf('brush:');
+      if ((brushIndex !== -1) && (brushIndex < node.properties.className.length-1)) {
+        lang = node.properties.className[brushIndex + 1];
+      }
+    }
+  }
+
+  return h(node, 'code', {lang: lang || null, meta: null}, trim(toText(node)))
+}

--- a/scripts/scraper/code.js
+++ b/scripts/scraper/code.js
@@ -2,7 +2,6 @@
 
 module.exports = code
 
-const is = require('hast-util-is-element');
 const has = require('hast-util-has-property');
 const toText = require('hast-util-to-text');
 const trim = require('trim-trailing-lines');

--- a/scripts/scraper/to-markdown.js
+++ b/scripts/scraper/to-markdown.js
@@ -2,6 +2,7 @@ const unified = require('unified');
 const parse = require('rehype-parse');
 const stringify = require('remark-stringify');
 const rehype2remark = require('rehype-remark');
+const code = require('./code');
 
 /**
  * Converts the HTML -> Markdown using unified.
@@ -9,8 +10,8 @@ const rehype2remark = require('rehype-remark');
 function toMarkdown(html) {
   return unified()
     .use(parse)
-    .use(rehype2remark)
-    .use(stringify)
+    .use(rehype2remark, {handlers: {pre: code}})
+    .use(stringify, {fences: true})
     .process(html);
 }
 


### PR DESCRIPTION
Fix for https://github.com/mdn/stumptown-content/issues/165.

This implements a custom handler for `<pre>` blocks, that preserves language information for blocks that use the `brush: html` classes to mark up language.

The default handler is here: https://github.com/syntax-tree/hast-util-to-mdast/blob/master/lib/handlers/code.js - it looks for classes like `language-javascript`, that we don't use.

Although I don't really know what I am doing, I'm quite excited about the possibility of being able to reach inside the Markdown conversion process like this.
