### PR TITLE
always close the dom

### DIFF
--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -91,6 +91,7 @@ async function processDoc(relativeURL, title, destination) {
   const md = String(await toMarkdown(result.dom.serialize()));
   const frontMatter = `---\ntitle: '${title}'\nmdn_url: ${relativeURL}\n${result.frontMatter}---\n`;
   writeDoc(destination, relativeURL.split('/').pop(), `${frontMatter}${md}\n`);
+  dom.window.close();
 }
 
 /**


### PR DESCRIPTION
JSDOM instances leak. Too many instances around in memory can cause an out-of-memory crash in NodeJS. I don't know if there's ever a page that has so many children that it'll actually blow up :)