### PR TITLE
Add missing recipe for guide pages

### DIFF
--- a/recipes/guide.yaml
+++ b/recipes/guide.yaml
@@ -1,0 +1,2 @@
+# The recipe for guide pages doesn't specify anything, because guide pages are unstructured.
+body: []

--- a/recipes/landing-page.yaml
+++ b/recipes/landing-page.yaml
@@ -1,0 +1,3 @@
+body:
+- prose.overview
+- meta.link_lists

--- a/recipes/landing-page.yaml
+++ b/recipes/landing-page.yaml
@@ -1,3 +1,0 @@
-body:
-- prose.overview
-- meta.link_lists


### PR DESCRIPTION
This should fix most of the linter errors by adding an empty recipe for guide pages, as suggested in https://github.com/mdn/stumptown-content/pull/169#discussion_r335410205.

I went back and forth about adding one for landing pages. But I think we can treat landing pages as normal recipe-driven pages, which would be nice. But also involves changes to build-json. So I thought it might be better to have it in a separate PR (and not rot https://github.com/mdn/stumptown-content/pull/190).