### PR TITLE
Start the linter on a specific directory

### DIFF
--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -34,6 +34,10 @@ function main(args) {
 
     const reportedFiles = [];
 
+    if (args.length === 0) {
+        args.push(undefined); // use default starting directory
+    }
+
     for (const arg of args) {
         for (const fp of walkDocs(arg)) {
             const file = vfile.readSync(fp);

--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -35,7 +35,7 @@ function main(args) {
     const reportedFiles = [];
 
     if (args.length === 0) {
-        args.push(undefined); // use default starting directory
+        args.push("content");
     }
 
     for (const arg of args) {

--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -14,7 +14,7 @@ const validRecipe = require("./plugins/valid-recipes");
 const walkDocs = require("./walk-docs");
 const yamlLoader = require("./plugins/yaml-loader");
 
-function main() {
+function main(args) {
     const recipes = collectRecipes();
 
     const markdownParser = unified()
@@ -34,10 +34,12 @@ function main() {
 
     const reportedFiles = [];
 
-    for (const fp of walkDocs()) {
-        const file = vfile.readSync(fp);
-        markdownParser().processSync(file);
-        reportedFiles.push(file);
+    for (const arg of args) {
+        for (const fp of walkDocs(arg)) {
+            const file = vfile.readSync(fp);
+            markdownParser().processSync(file);
+            reportedFiles.push(file);
+        }
     }
 
     console.error(report(reportedFiles, { quiet: true }));
@@ -47,5 +49,5 @@ function main() {
 }
 
 if (require.main === module) {
-    main();
+    main(process.argv.slice(2));
 }

--- a/scripts/linter/walk-docs.js
+++ b/scripts/linter/walk-docs.js
@@ -4,7 +4,7 @@ const path = require("path");
 /**
  * Walks the content directory tree (`start`) yielding Markdown files.
  */
-function* walkDocs(start = "content") {
+function* walkDocs(start) {
     const files = fs.readdirSync(start, { withFileTypes: true });
 
     for (const f of files) {


### PR DESCRIPTION
A quick-and-dirty PR that lets you provide a starting directory to the linter, like so:

```shell
$ npm run lint-md -- content/html/reference/elements/abbr
```

This means you can lint only the content you're working on and ignore warnings or errors for other stuff.