### PR TITLE
Lint for missing frontmatter that will break build-json

### DIFF
--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -9,10 +9,7 @@ body:
 - prose.*
 - prose.accessibility-concerns?
 - meta.examples
-- meta.info-box?:
-    - meta.animatable
-    - meta.initial-value
-    - meta.shorthand-for
+- meta.info-box?
 - meta.specifications
 - meta.browser-compatibility
 - prose.see-also

--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -9,7 +9,7 @@ body:
 - prose.*
 - prose.accessibility-concerns?
 - meta.examples
-- meta.info-box:
+- meta.info-box?:
     - meta.animatable
     - meta.initial-value
     - meta.shorthand-for

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -9,7 +9,7 @@ body:
 - prose.accessibility_concerns?
 - prose.*
 - meta.examples
-- meta.info_box
+- meta.info_box?
 - meta.specifications
 - meta.browser_compatibility
 - prose.see_also

--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -11,7 +11,7 @@ body:
 - prose.accessibility_concerns?
 - prose.*
 - meta.examples
-- meta.info_box
+- meta.info_box?
 - meta.specifications
 - meta.browser_compatibility
 - prose.see_also

--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -9,6 +9,7 @@ const vfile = require("to-vfile");
 const collectRecipes = require("./collect-recipes");
 const deprecatedSections = require("./plugins/deprecated-sections");
 const missingSections = require("./plugins/missing-sections");
+const requiredFrontmatter = require("./plugins/required-frontmatter");
 const slugifySections = require("./plugins/slugify-sections");
 const validRecipe = require("./plugins/valid-recipes");
 const walkDocs = require("./walk-docs");
@@ -23,6 +24,7 @@ function main() {
         .use(frontmatter, ["yaml"])
         .use(yamlLoader)
         .use(validRecipe, { recipes })
+        .use(requiredFrontmatter)
         .use(slugifySections)
         .use(deprecatedSections, {
             sections: {

--- a/scripts/linter/plugins/required-frontmatter.js
+++ b/scripts/linter/plugins/required-frontmatter.js
@@ -1,0 +1,45 @@
+const ruleId = "stumptown-linter:frontmatter-required-keys";
+
+/**
+ * If a tree has `tree.data.recipe` (i.e., it's a Markdown doc with a
+ * known-valid recipe), then log messages if it's missing essential frontmatter.
+ */
+function attacher() {
+    return function transformer(tree, file) {
+        if (tree.data && tree.data.recipe) {
+            const { yaml } = tree.children[0].data;
+            const requiredFrontmatter = [];
+
+            // Right now, there's no way to collect the required frontmatter
+            // keys from the recipe itself, so they're hardcoded for now.
+            if (yaml.recipe === "html-element") {
+                requiredFrontmatter.push(
+                    "attributes",
+                    "attributes.global",
+                    "examples"
+                );
+            }
+
+            for (const key of requiredFrontmatter) {
+                // This Rube Goldberg machine will try to look up `a.b.c` and
+                // throw (and log a message) if `a.b.c` is undefined or if any
+                // of `a` or `b` are undefined
+                try {
+                    const obj = key.split(".").reduce((o, i) => o[i], yaml);
+                    if (obj === undefined) {
+                        throw `${key} not found`;
+                    }
+                } catch (err) {
+                    const message = file.message(
+                        `\`${key}\` frontmatter key not found`,
+                        tree.children[0],
+                        ruleId
+                    );
+                    message.fatal = true;
+                }
+            }
+        }
+    };
+}
+
+module.exports = attacher;

--- a/scripts/linter/plugins/required-frontmatter.js
+++ b/scripts/linter/plugins/required-frontmatter.js
@@ -5,13 +5,6 @@ const ruleId = "stumptown-linter:frontmatter-required-keys";
  */
 function required(recipe) {
     return recipe.body
-        .map(entry => {
-            if (typeof entry === "string") {
-                return entry;
-            } else {
-                return Object.keys(entry)[0];
-            }
-        })
         .filter(
             entry =>
                 typeof entry === "string" &&

--- a/scripts/linter/plugins/required-frontmatter.js
+++ b/scripts/linter/plugins/required-frontmatter.js
@@ -8,7 +8,7 @@ function required(recipe) {
         .map(entry => {
             if (typeof entry === "string") {
                 return entry;
-            } else if (typeof entry === "object") {
+            } else {
                 return Object.keys(entry)[0];
             }
         })


### PR DESCRIPTION
While working on #207, I wrote this to check for `build-json`-breaking frontmatter omissions. It's only got a few right now, and they're hard coded, but I imagine we can build on this. Thankfully, this doesn't introduce any _new_ warnings. 😃 