### PR TITLE
Remove Promise.all from compose-attributes

### DIFF
--- a/scripts/build-json/compose-attributes.js
+++ b/scripts/build-json/compose-attributes.js
@@ -76,7 +76,7 @@ function getAttributePaths(root, attributesKey) {
 
 function packageAttributes(root, attributesKey) {
     const attributePaths = getAttributePaths(root, attributesKey);
-    return Promise.all(attributePaths.map(packageAttribute));
+    return attributePaths.map(packageAttribute);
 }
 
 module.exports = {


### PR DESCRIPTION
https://github.com/mdn/stumptown-content/pull/190 missed a call to Promise.all in compose-attributes.js, which broke attribute building.