### PR TITLE
Fix lint errors for CSS properties

### DIFF
--- a/content/css/reference/properties/border-block-start-width/border-block-start-width.md
+++ b/content/css/reference/properties/border-block-start-width/border-block-start-width.md
@@ -1,12 +1,12 @@
 ---
 title: border-block-start-width
-mdn-url: https://developer.mozilla.org/docs/Web/CSS/border-block-start-width
+mdn_url: https://developer.mozilla.org/docs/Web/CSS/border-block-start-width
 recipe: css-property
-interactive-example: https://interactive-examples.mdn.mozilla.net/pages/css/border-block-start-width.html
-formal-syntax: <'border-top-width'>
+interactive_example: https://interactive-examples.mdn.mozilla.net/pages/css/border-block-start-width.html
+formal_syntax: <'border-top-width'>
 animatable: discrete
-initial-value: medium
-browser-compatibility: css.properties.border-block-start-width
+initial_value: medium
+browser_compatibility: css.properties.border-block-start-width
 examples:
     - examples/simple-example
 ---

--- a/content/css/reference/properties/border/border.md
+++ b/content/css/reference/properties/border/border.md
@@ -1,16 +1,16 @@
 ---
 title: border
-mdn-url: https://developer.mozilla.org/docs/Web/CSS/border
+mdn_url: https://developer.mozilla.org/docs/Web/CSS/border
 recipe: css-property
-interactive-example: https://interactive-examples.mdn.mozilla.net/pages/css/border.html
-formal-syntax: '<line-width> || <line-style> || <color>'
-shorthand-for:
+interactive_example: https://interactive-examples.mdn.mozilla.net/pages/css/border.html
+formal_syntax: '<line-width> || <line-style> || <color>'
+shorthand_for:
     - border-width
     - border-style
     - border-color
 animatable:
-initial-value:
-browser-compatibility: css.properties.border
+initial_value:
+browser_compatibility: css.properties.border
 examples:
     - examples/simple-example
 ---

--- a/content/css/reference/properties/transform/transform.md
+++ b/content/css/reference/properties/transform/transform.md
@@ -1,12 +1,12 @@
 ---
 title: transform
-mdn-url: https://developer.mozilla.org/docs/Web/CSS/transform
+mdn_url: https://developer.mozilla.org/docs/Web/CSS/transform
 recipe: css-property
-interactive-example: https://interactive-examples.mdn.mozilla.net/pages/css/transform.html
-formal-syntax: 'none | <transform-list>'
+interactive_example: https://interactive-examples.mdn.mozilla.net/pages/css/transform.html
+formal_syntax: 'none | <transform-list>'
 animatable: true
-initial-value: none
-browser-compatibility: css.properties.transform
+initial_value: none
+browser_compatibility: css.properties.transform
 examples:
     - examples/simple-example
 ---

--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -1,15 +1,13 @@
 body:
-- prose.short-description
-- meta.interactive-example
-- prose.overview
-- prose.syntax-overview
-- prose.example-syntax
-- meta.values
-- meta.formal-syntax
-- prose.*
-- prose.accessibility-concerns?
-- meta.examples
-- meta.info-box?
-- meta.specifications
-- meta.browser-compatibility
-- prose.see-also
+  - prose.short_description
+  - meta.interactive_example
+  - prose.overview
+  - prose.syntax_overview
+  - prose.example_syntax
+  - meta.formal_syntax
+  - prose.*
+  - prose.accessibility_concerns?
+  - meta.examples
+  - meta.info_box?
+  - meta.browser_compatibility
+  - prose.see_also


### PR DESCRIPTION
The linter now complains about errors in the CSS properties. This PR, I hope, fixes them. I had half a mind to just delete them all but thought perhaps they are worth keeping for now. Still, I've tried to keep to changes that are obviously good (e.g. "-" to "_") and haven't made any changes that involved nontrivial work (so, I just removed `specifications` rather than adding the specs now).
