### PR TITLE
Remove BCD section text during scraping

### DIFF
--- a/scripts/scraper/clean-html.js
+++ b/scripts/scraper/clean-html.js
@@ -19,7 +19,27 @@ function removeHiddenDivs(dom) {
   }
 }
 
+function removeBrowserCompatibility(dom) {
+  // Note: This assumes that hidden content has been removed and macros have been processed out of dom.
+
+  const compatHeading = dom.window.document.querySelector(
+    "#Browser_compatibility"
+  );
+
+  // Make sure that there's no content under the compat heading by making sure
+  // the next elmeent after the compat heading is another heading.
+  const nextElement = compatHeading.nextElementSibling;
+  if (nextElement !== null && nextElement.tagName !== "H2") {
+    console.error("There's unexpected content in the BCD section.");
+    console.error(nextElement, nextElement.tagName, nextElement.innerHTML);
+    process.exit(1);
+  }
+
+  compatHeading.parentNode.removeChild(compatHeading);
+}
+
 module.exports = {
+  removeBrowserCompatibility,
   removeHiddenDivs,
   removeNode,
   removeTitleAttributes

--- a/scripts/scraper/clean-html.js
+++ b/scripts/scraper/clean-html.js
@@ -35,7 +35,7 @@ function removeBrowserCompatibility(dom) {
   );
   hiddenElements.forEach(hidden => hidden.remove());
 
-  if (sectionWrapper.childNodes.length > 0) {
+  if (sectionWrapper.hasChildNodes()) {
     console.error("There's unexpected content in the BCD section.");
     console.error(sectionWrapper.innerHTML);
     process.exit(1);

--- a/scripts/scraper/clean-html.js
+++ b/scripts/scraper/clean-html.js
@@ -12,35 +12,44 @@ function removeNode(dom, selector) {
   }
 }
 
-function removeHiddenDivs(dom) {
-  const hiddenDivs = dom.window.document.querySelectorAll("div.hidden");
-  for (const hiddenDiv of hiddenDivs) {
-    hiddenDiv.parentNode.removeChild(hiddenDiv);
-  }
-}
-
 function removeBrowserCompatibility(dom) {
-  // Note: This assumes that hidden content has been removed and macros have been processed out of dom.
+  // Find the start of the compat section
+  const heading = dom.window.document.querySelector("#Browser_compatibility");
 
-  const compatHeading = dom.window.document.querySelector(
-    "#Browser_compatibility"
+  // Wrap the content the compat section in a div (stopping at the next heading
+  // or the end of the page)
+  const sectionWrapper = dom.window.document.createElement("div");
+  sectionWrapper.id = "bcd-section-wrapper";
+
+  let current = heading.nextElementSibling;
+  while (current !== null && current.tagName !== "H2") {
+    const next = current.nextElementSibling;
+    sectionWrapper.appendChild(current);
+    current = next;
+  }
+  heading.parentNode.insertBefore(sectionWrapper, heading.nextElementSibling);
+
+  // Remove any .hidden elements in the compat section
+  const hiddenElements = dom.window.document.querySelectorAll(
+    "#bcd-section-wrapper .hidden"
   );
+  for (const hidden of hiddenElements) {
+    hidden.parentNode.removeChild(hidden);
+  }
 
-  // Make sure that there's no content under the compat heading by making sure
-  // the next elmeent after the compat heading is another heading.
-  const nextElement = compatHeading.nextElementSibling;
-  if (nextElement !== null && nextElement.tagName !== "H2") {
+  if (sectionWrapper.childNodes.length > 0) {
     console.error("There's unexpected content in the BCD section.");
-    console.error(nextElement, nextElement.tagName, nextElement.innerHTML);
+    console.error(sectionWrapper.innerHTML);
     process.exit(1);
   }
 
-  compatHeading.parentNode.removeChild(compatHeading);
+  // Finally, remove the heading
+  heading.parentNode.removeChild(heading);
+  sectionWrapper.parentNode.removeChild(sectionWrapper);
 }
 
 module.exports = {
   removeBrowserCompatibility,
-  removeHiddenDivs,
   removeNode,
   removeTitleAttributes
 };

--- a/scripts/scraper/clean-html.js
+++ b/scripts/scraper/clean-html.js
@@ -33,9 +33,7 @@ function removeBrowserCompatibility(dom) {
   const hiddenElements = dom.window.document.querySelectorAll(
     "#bcd-section-wrapper .hidden"
   );
-  for (const hidden of hiddenElements) {
-    hidden.parentNode.removeChild(hidden);
-  }
+  hiddenElements.forEach(hidden => hidden.remove());
 
   if (sectionWrapper.childNodes.length > 0) {
     console.error("There's unexpected content in the BCD section.");
@@ -43,9 +41,9 @@ function removeBrowserCompatibility(dom) {
     process.exit(1);
   }
 
-  // Finally, remove the heading
-  heading.parentNode.removeChild(heading);
-  sectionWrapper.parentNode.removeChild(sectionWrapper);
+  // Finally remove the BCD source
+  heading.remove();
+  sectionWrapper.remove();
 }
 
 module.exports = {

--- a/scripts/scraper/clean-html.js
+++ b/scripts/scraper/clean-html.js
@@ -12,7 +12,15 @@ function removeNode(dom, selector) {
   }
 }
 
+function removeHiddenDivs(dom) {
+  const hiddenDivs = dom.window.document.querySelectorAll("div.hidden");
+  for (const hiddenDiv of hiddenDivs) {
+    hiddenDiv.parentNode.removeChild(hiddenDiv);
+  }
+}
+
 module.exports = {
-  removeTitleAttributes,
-  removeNode
+  removeHiddenDivs,
+  removeNode,
+  removeTitleAttributes
 };

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -27,9 +27,10 @@ const { JSDOM } = jsdom;
 
 const { toMarkdown } = require("./to-markdown.js");
 const {
-  removeTitleAttributes,
+  removeBrowserCompatibility,
+  removeHiddenDivs,
   removeNode,
-  removeHiddenDivs
+  removeTitleAttributes
 } = require("./clean-html.js");
 const {
   processInteractiveExample
@@ -97,11 +98,7 @@ async function processDoc(relativeURL, title, destination) {
 
   const result = await processMacros(dom, relativeURL, destination);
 
-  // Remove Browser compatability section, now that its been consumed by
-  // `processMacros`. This will work as long as there's at least one section
-  // after BCD, which should be the case.
-  removeNode(dom, "#Browser_compatibility ~ :not(H2)");
-  removeNode(dom, "#Browser_compatibility");
+  removeBrowserCompatibility(dom);
 
   const md = String(await toMarkdown(result.dom.serialize()));
   const frontMatter = `---\ntitle: '${title}'\nmdn_url: ${relativeURL}\n${result.frontMatter}---\n`;

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -26,7 +26,11 @@ const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 
 const { toMarkdown } = require("./to-markdown.js");
-const { removeTitleAttributes, removeNode } = require("./clean-html.js");
+const {
+  removeTitleAttributes,
+  removeNode,
+  removeHiddenDivs
+} = require("./clean-html.js");
 const {
   processInteractiveExample
 } = require("./process-macros/process-interactive-example");
@@ -88,7 +92,9 @@ async function processDoc(relativeURL, title, destination) {
   const mdnPage = await getPageHTML(baseURL + relativeURL + "?raw&macros");
   const dom = new JSDOM(mdnPage);
   removeTitleAttributes(dom);
+  removeHiddenDivs(dom);
   removeNode(dom, "section.Quick_links");
+
   const result = await processMacros(dom, relativeURL, destination);
 
   // Remove Browser compatability section, now that its been consumed by

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -28,7 +28,6 @@ const { JSDOM } = jsdom;
 const { toMarkdown } = require("./to-markdown.js");
 const {
   removeBrowserCompatibility,
-  removeHiddenDivs,
   removeNode,
   removeTitleAttributes
 } = require("./clean-html.js");
@@ -93,7 +92,6 @@ async function processDoc(relativeURL, title, destination) {
   const mdnPage = await getPageHTML(baseURL + relativeURL + "?raw&macros");
   const dom = new JSDOM(mdnPage);
   removeTitleAttributes(dom);
-  removeHiddenDivs(dom);
   removeNode(dom, "section.Quick_links");
 
   const result = await processMacros(dom, relativeURL, destination);

--- a/scripts/scraper/scrape-mdn.js
+++ b/scripts/scraper/scrape-mdn.js
@@ -90,6 +90,13 @@ async function processDoc(relativeURL, title, destination) {
   removeTitleAttributes(dom);
   removeNode(dom, "section.Quick_links");
   const result = await processMacros(dom, relativeURL, destination);
+
+  // Remove Browser compatability section, now that its been consumed by
+  // `processMacros`. This will work as long as there's at least one section
+  // after BCD, which should be the case.
+  removeNode(dom, "#Browser_compatibility ~ :not(H2)");
+  removeNode(dom, "#Browser_compatibility");
+
   const md = String(await toMarkdown(result.dom.serialize()));
   const frontMatter = `---\ntitle: '${title}'\nmdn_url: ${relativeURL}\n${result.frontMatter}---\n`;
   writeDoc(destination, relativeURL.split("/").pop(), `${frontMatter}${md}\n`);


### PR DESCRIPTION
I tired my hand at modifying the scraper to remove BCD sections from the final prose Markdown.

`scrape-mdn.js` has not been prettier-ed yet, so my first commit here does that. You might find this easier to review if you use GitHub's diff commit picker to see only the meaningful changes in the second commit (0737b6e).

Fixes #210.