### PR TITLE
Lint for specifications section

### DIFF
--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -28,7 +28,7 @@ function main(args) {
     .use(slugifySections)
     .use(deprecatedSections, {
       sections: {
-        "html-element": ["usage_notes"],
+        "html-element": ["usage_notes", "specifications"],
         "css-property": ["usage_notes"]
       }
     })


### PR DESCRIPTION
As a courtesy to authors using the scraper, this change will caution you against leaving in a `## Specifications` section (since you should use the `specifications` frontmatter instead).