### PR TITLE
Linter: fix bug visiting headings repeatedly

### DIFF
--- a/scripts/linter/plugins/missing-sections.js
+++ b/scripts/linter/plugins/missing-sections.js
@@ -31,7 +31,9 @@ function attacher() {
       visit(
         tree,
         node => node.data && node.data.slug,
-        node => actualSections.push(node.data.slug)
+        node => {
+          actualSections.push(`h${node.depth}.` + node.data.slug);
+        }
       );
 
       for (const section of expectedSections) {


### PR DESCRIPTION
The return value of the visitor function for [unist-util-visit](https://github.com/syntax-tree/unist-util-visit#next--visitornode-index-parent) is used to continue (`true`), break (`false`), or change the visit (with an index or node). I was accidentally returning the length of an array, which caused headings to be visited multiple times. This PR fixes that problem.