### PR TITLE
Specify more frontmatter in recipes

### DIFF
--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -1,3 +1,7 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
 body:
   - prose.short_description
   - meta.interactive_example

--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -4,14 +4,14 @@ data:
   - mdn_url
 body:
   - prose.short_description
-  - meta.interactive_example
+  - data.interactive_example
   - prose.overview
   - prose.syntax_overview
   - prose.example_syntax
-  - meta.formal_syntax
+  - data.formal_syntax
   - prose.*
   - prose.accessibility_concerns?
-  - meta.examples
-  - meta.info_box?
-  - meta.browser_compatibility
+  - data.examples
+  - data.info_box?
+  - data.browser_compatibility
   - prose.see_also

--- a/recipes/guide.yaml
+++ b/recipes/guide.yaml
@@ -1,2 +1,6 @@
 # The recipe for guide pages doesn't specify anything, because guide pages are unstructured.
+data:
+- title
+- short_title?
+- mdn_url
 body: []

--- a/recipes/guide.yaml
+++ b/recipes/guide.yaml
@@ -1,4 +1,5 @@
-# The recipe for guide pages doesn't specify anything, because guide pages are unstructured.
+# The recipe for guide pages doesn't specify anything in the body, because guide
+# pages are unstructured.
 data:
 - title
 - short_title?

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -5,15 +5,15 @@ data:
 - mdn_url
 body:
 - prose.short_description
-- meta.interactive_example?
+- data.interactive_example?
 - prose.overview
 - prose.attributes_text?
-- meta.attributes
+- data.attributes
 - prose.styling?
 - prose.accessibility_concerns?
 - prose.*
-- meta.examples
-- meta.info_box?
-- meta.specifications
-- meta.browser_compatibility
+- data.examples
+- data.info_box?
+- data.specifications
+- data.browser_compatibility
 - prose.see_also

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -1,4 +1,8 @@
 related_content: /content/related_content/html.yaml
+data:
+- title
+- short_title?
+- mdn_url
 body:
 - prose.short_description
 - meta.interactive_example?

--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -1,4 +1,8 @@
 related_content: /content/related_content/html.yaml
+data:
+- title
+- short_title?
+- mdn_url
 body:
 - prose.short_description
 - meta.interactive_example?

--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -5,17 +5,17 @@ data:
 - mdn_url
 body:
 - prose.short_description
-- meta.interactive_example?
+- data.interactive_example?
 - prose.overview
 - prose.value
 - prose.validation
 - prose.attributes_text?
-- meta.attributes
+- data.attributes
 - prose.styling?
 - prose.accessibility_concerns?
 - prose.*
-- meta.examples
-- meta.info_box?
-- meta.specifications
-- meta.browser_compatibility
+- data.examples
+- data.info_box?
+- data.specifications
+- data.browser_compatibility
 - prose.see_also

--- a/recipes/landing-page.yaml
+++ b/recipes/landing-page.yaml
@@ -4,4 +4,4 @@ data:
 - mdn_url
 body:
 - prose.overview
-- meta.link_lists
+- data.link_lists

--- a/recipes/landing-page.yaml
+++ b/recipes/landing-page.yaml
@@ -1,3 +1,7 @@
+data:
+- title
+- short_title?
+- mdn_url
 body:
 - prose.overview
 - meta.link_lists

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -67,7 +67,7 @@ function buildRecipePageJSON(elementPath, data, content, recipe) {
     const [ingredientType, ingredientName] = ingredient
       .replace(/\?$/, "")
       .split(".");
-    if (ingredientType === "meta") {
+    if (ingredientType === "data") {
       // non-prose ingredients, which are specified in front matter
       const value = processMetaIngredient(elementPath, ingredientName, data);
       if (value !== null) {

--- a/scripts/linter/plugins/required-frontmatter.js
+++ b/scripts/linter/plugins/required-frontmatter.js
@@ -4,7 +4,8 @@ const ruleId = "stumptown-linter:frontmatter-required-keys";
  * Extract the keys of required top-level frontmatter from a recipe.
  */
 function required(recipe) {
-  return recipe.body
+  const data = recipe.data.filter(entry => !entry.endsWith("?"));
+  const body = recipe.body
     .filter(
       entry =>
         typeof entry === "string" &&
@@ -12,6 +13,8 @@ function required(recipe) {
         !entry.endsWith("?")
     )
     .map(entry => entry.match("data.(.*)")[1]);
+
+  return data.concat(body);
 }
 
 /**

--- a/scripts/linter/plugins/required-frontmatter.js
+++ b/scripts/linter/plugins/required-frontmatter.js
@@ -8,10 +8,10 @@ function required(recipe) {
     .filter(
       entry =>
         typeof entry === "string" &&
-        entry.startsWith("meta.") &&
+        entry.startsWith("data.") &&
         !entry.endsWith("?")
     )
-    .map(entry => entry.match("meta.(.*)")[1]);
+    .map(entry => entry.match("data.(.*)")[1]);
 }
 
 /**


### PR DESCRIPTION
This PR adds a `data` section to recipes, which specifies additional frontmatter fields that are used when building the recipe, such as `mdn_url` or `title`. Consequently this PR also:

* renames the recipe body `meta.*`entries to `data.*`
* updates the linter and `build-json` use `data.<attribute>` instead of `meta.<attribute>`
* lints frontmatter for `data` entries

Fixes #203.