### PR TITLE
Add a linter for specifications

### DIFF
--- a/content/en-US/html/HTML.md
+++ b/content/en-US/html/HTML.md
@@ -1,7 +1,7 @@
 ---
 title: "HTML: Hypertext Markup Language"
 mdn_url: /en-US/docs/Web/HTML
-specifications: https://html.spec.whatwg.org/multipage/
+specifications: https://html.spec.whatwg.org/multipage/introduction.html#abstract
 recipe: landing-page
 related_content: /related_content/html.yaml
 link_lists:

--- a/scripts/linter/index.js
+++ b/scripts/linter/index.js
@@ -14,6 +14,7 @@ const slugifySections = require("./plugins/slugify-sections");
 const validRecipe = require("./plugins/valid-recipes");
 const walkDocs = require("./walk-docs");
 const yamlLoader = require("./plugins/yaml-loader");
+const validSpecs = require("./plugins/valid-specs");
 
 function main(args) {
   const recipes = collectRecipes();
@@ -25,6 +26,7 @@ function main(args) {
     .use(yamlLoader)
     .use(validRecipe, { recipes })
     .use(requiredFrontmatter)
+    .use(validSpecs)
     .use(slugifySections)
     .use(deprecatedSections, {
       sections: {

--- a/scripts/linter/plugins/valid-specs.js
+++ b/scripts/linter/plugins/valid-specs.js
@@ -1,0 +1,53 @@
+const visit = require("unist-util-visit");
+const yaml = require("js-yaml");
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, "..", "..", "..");
+const dataDir = path.resolve(ROOT, 'content', 'data');
+const specMap = yaml.safeLoad(fs.readFileSync(path.join(dataDir, 'specifications.yaml'), 'utf8'));
+
+const ruleId = "stumptown-linter:valid-specifications";
+const specURLRegex = new RegExp("^http(s)?://[^#]+#.+");
+
+/**
+ * Check the front-matter for valid `specifications`
+ */
+function attacher() {
+    return function transformer(tree, file) {
+        visit(tree, "yaml", node => {
+            let specs = node.data.yaml.specifications;
+            // specifications are optional
+            if (specs) {
+                // specifications can be single url or array of urls
+                if (!Array.isArray(specs)) {
+                    specs = [specs];
+                }
+                specs.forEach(spec => {
+                    // "non-standard" is a special string indicating that there is no spec. Allow this one.
+                    if (spec === 'non-standard') {
+                      return;
+                    }
+                    // Any other strings should be URLs and provide a deep link to a spec section.
+                    if (!specURLRegex.test(spec)) {
+                        const message = file.message(`"${spec}" is not a valid specification link (anchored deep link required).`, node, ruleId);
+                        message.fatal = true;
+                    }
+                    // Spec URLs should be allow-listed, so that we don't list any outdated specs
+                    let found = false;
+                    Object.keys(specMap).forEach((key) => {
+                        if (spec.includes(key)) {
+                            found = true;
+                        }
+                      });
+                    if (!found) {
+                      const message = file.message(`Domain for "${spec}" not found in data/specifications.yaml`, node, ruleId);
+                      message.fatal = true;
+                    }
+                });
+            }
+        });
+    };
+}
+
+module.exports = attacher;

--- a/scripts/linter/plugins/valid-specs.js
+++ b/scripts/linter/plugins/valid-specs.js
@@ -33,16 +33,11 @@ function attacher() {
                         const message = file.message(`"${spec}" is not a valid specification link (anchored deep link required).`, node, ruleId);
                         message.fatal = true;
                     }
-                    // Spec URLs should be allow-listed, so that we don't list any outdated specs
-                    let found = false;
-                    Object.keys(specMap).forEach((key) => {
-                        if (spec.includes(key)) {
-                            found = true;
-                        }
-                      });
-                    if (!found) {
-                      const message = file.message(`Domain for "${spec}" not found in data/specifications.yaml`, node, ruleId);
-                      message.fatal = true;
+                    // Spec URLs should be allow-listed, so that we don't list any outdated specs.
+                    const allowedSpecs = Object.keys(specMap);
+                    if (!allowedSpecs.some(key => spec.includes(key))) {
+                        const message = file.message(`Domain for "${spec}" not found in data/specifications.yaml`, node, ruleId);
+                        message.fatal = true;
                     }
                 });
             }


### PR DESCRIPTION
As said (and specified) in https://github.com/mdn/stumptown-content/issues/126, here's a linter for the `specifications` front-matter.