### PR TITLE
Add all JS recipes

### DIFF
--- a/recipes/javascript-constructor.yaml
+++ b/recipes/javascript-constructor.yaml
@@ -1,0 +1,15 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/javascript-error.yaml
+++ b/recipes/javascript-error.yaml
@@ -1,0 +1,12 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.message
+  - prose.error_type
+  - prose.what_went_wrong
+  - data.examples
+  - prose.see_also

--- a/recipes/javascript-expression.yaml
+++ b/recipes/javascript-expression.yaml
@@ -1,0 +1,15 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/javascript-operator.yaml
+++ b/recipes/javascript-operator.yaml
@@ -1,0 +1,15 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/javascript-property.yaml
+++ b/recipes/javascript-property.yaml
@@ -1,0 +1,15 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.description
+  - data.info_box
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/javascript-statement.yaml
+++ b/recipes/javascript-statement.yaml
@@ -1,0 +1,15 @@
+related_content: /content/related_content/javascript.yaml
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also


### PR DESCRIPTION
This adds recipes for all the remaining JS page types, following the discussion in London.

Five of them (expression, statement, method, operator, constructor) are the same. I think this is OK as long as we don't end up with too many page types in there, which I don't think we will (it would be confusing if different page types shared recipes). But we might perhaps want to reconsider this as we get more recipes written.