### PR TITLE
Fix regressions and errors in JS support

### DIFF
--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -1,4 +1,4 @@
-related_content: /related_content/html.yaml
+related_content: related_content/html.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-class.yaml
+++ b/recipes/javascript-class.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-constructor.yaml
+++ b/recipes/javascript-constructor.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-error.yaml
+++ b/recipes/javascript-error.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-expression.yaml
+++ b/recipes/javascript-expression.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-method.yaml
+++ b/recipes/javascript-method.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-operator.yaml
+++ b/recipes/javascript-operator.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-property.yaml
+++ b/recipes/javascript-property.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/recipes/javascript-statement.yaml
+++ b/recipes/javascript-statement.yaml
@@ -1,4 +1,4 @@
-related_content: /content/related_content/javascript.yaml
+related_content: related_content/javascript.yaml
 data:
   - title
   - short_title?

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -16,10 +16,7 @@ function processMetaIngredient(elementPath, ingredientName, data) {
   }
   switch (ingredientName) {
     case "interactive_example":
-      return {
-        type: "interactive_example",
-        value: packageInteractiveExample(data.interactive_example)
-      };
+      return packageInteractiveExample(data.interactive_example);
     case "specifications":
       return packageSpecs(data.specifications);
     case "browser_compatibility":

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -5,6 +5,8 @@ const { JSDOM } = jsdom;
 const namedSections = [
   "Short description",
   "Overview",
+  "Syntax",
+  "Description",
   "Attributes",
   "Usage notes",
   "Accessibility concerns",

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -5,8 +5,6 @@ const { JSDOM } = jsdom;
 const namedSections = [
   "Short description",
   "Overview",
-  "Syntax",
-  "Description",
   "Attributes",
   "Usage notes",
   "Accessibility concerns",


### PR DESCRIPTION
The fix for https://github.com/mdn/stumptown-content/pull/243 was not complete: the locale support work also meant that recipes now refer to related_content using a path relative to the current locale.

Also, my PR to add JS support regressed interactive examples.

This PR is intended to fix both of these problems, so JS pages should more or less work.

I've tested it using a version of the renderer modified to render the JS pages.
