### PR TITLE
Fix spec link that fails the build

### DIFF
--- a/content/fr/html/HTML.md
+++ b/content/fr/html/HTML.md
@@ -1,7 +1,7 @@
 ---
 title: "HTML: Hypertext Markup Language"
 mdn_url: /fr/docs/Web/HTML
-specifications: https://html.spec.whatwg.org/multipage/
+specifications: https://html.spec.whatwg.org/multipage/#table-of-contents
 recipe: landing-page
 related_content: /related_content/html.yaml
 link_lists:


### PR DESCRIPTION
This slipped through on https://github.com/mdn/stumptown-content/pull/231#issuecomment-554377417.