### PR TITLE
Show URL fetching progress

### DIFF
--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -43,6 +43,7 @@ async function run() {
   const limiter = RateLimit(4, { uniformDistribution: true });
   const files = urls.map(async url => {
     await limiter();
+    if (!argv.quiet) console.log(`Fetching ${url}`);
     const file = await toVFile(url);
     const hasFileErrors = file.messages.length > 0;
     if (!hasFileErrors) {


### PR DESCRIPTION
This adds some output to show the progress of fetching URLs in the linter. I'm trying to spare you from having to do this every time:

> But personally, every time I run this on a fairly large set of files I will manually add `console.log(url);` before `processor.process`, so I can see how it is going.

From https://github.com/mdn/stumptown-content/pull/259#issuecomment-565129908.

You can suppress this output with the `--quiet/-q` option.