### PR TITLE
Summarize wiki tree linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,18 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@types/color-name": {
@@ -3307,13 +3319,49 @@
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "character-entities": {
@@ -3754,6 +3802,17 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -5015,6 +5074,16 @@
         "sinon-as-promised": "^4.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "js-yaml": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
@@ -6907,6 +6976,18 @@
         "minimist": "^1.2.0",
         "text-table": "^0.2.0",
         "unified-engine": "^7.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "unified-engine": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "remark-rehype": "5.0.0",
         "remark-retext": "^3.1.3",
         "remark-stringify": "7.0.4",
-        "retext-stringify": "^2.0.4"
+        "retext-stringify": "^2.0.4",
+        "vfile-statistics": "^1.1.3"
     },
     "remarkConfig": {
         "plugins": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "async-sema": "^3.0.1",
+        "chalk": "^3.0.0",
         "gray-matter": "4.0.2",
         "hast-util-find-and-replace": "^2.0.0",
         "js-yaml": "3.13.1",

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -1,9 +1,10 @@
 const { RateLimit } = require("async-sema");
 const fetch = require("node-fetch");
+const fileReporter = require("vfile-reporter");
 const rehype = require("rehype");
-const reporter = require("vfile-reporter");
 
 const mdnUrl = require("./mdn-url");
+const summaryReporter = require("./vfile-reporter-summary");
 const toVFile = require("./url-to-vfile");
 
 const examplePage =
@@ -65,6 +66,7 @@ async function run() {
   });
   const processed = await Promise.all(files);
 
+  const reporter = argv.summary ? summaryReporter : fileReporter;
   console.log(
     reporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
   );

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -10,23 +10,35 @@ const examplePage =
   "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div";
 const exampleShorthand = "/en-US/docs/Web/HTML/Element/div";
 
-const argv = require("yargs")
+const { argv } = require("yargs")
   .parserConfiguration({ "boolean-negation": false })
   .usage("Usage: $0 <url>")
   .example(`$0 ${examplePage}`, "scrape a page and all its subpages")
   .example(`$0 ${exampleShorthand}`, "omit the protocol and domain")
-  .example(`$0 --no-subpages ${exampleShorthand}`, "one page only")
+
+  .describe("n", "Dry run (lint-only)")
+  .alias("n", "dry-run")
   .example(`$0 -n ${exampleShorthand}`, "dry run (lint)")
-  .demandCommand(1, 1, "A URL is required", "Too many arguments")
+
   .describe("no-subpages", "Don't walk the entire tree from the URL")
   .default("no-subpages", false)
-  .describe("n", "Dry run (lint)")
-  .alias("n", "dry-run")
-  .describe("q", "Suppress success messages")
+  .example(`$0 --no-subpages ${exampleShorthand}`, "one page only")
+
+  .describe("q", "Suppress success and progress messages")
   .alias("q", "quiet")
+
+  .describe("summary", "Summarize messages across all pages")
+  .alias("s", "summary")
+  .example(
+    `$0 --summary ${exampleShorthand}`,
+    "summary of report of message types"
+  )
+
   .describe("v", "Expand linter notes, if applicable")
   .alias("v", "verbose")
-  .boolean(["n", "q", "v", "no-subpages"]).argv;
+
+  .demandCommand(1, 1, "A URL is required", "Too many arguments")
+  .boolean(["n", "no-subpages", "q", "s", "v"]);
 
 const processor = rehype()
   .use([require("./plugins/kumascript-macros")])

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -2,6 +2,7 @@ const { RateLimit } = require("async-sema");
 const fetch = require("node-fetch");
 const fileReporter = require("vfile-reporter");
 const rehype = require("rehype");
+const yargs = require("yargs");
 
 const mdnUrl = require("./mdn-url");
 const summaryReporter = require("./vfile-reporter-summary");
@@ -11,7 +12,7 @@ const examplePage =
   "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div";
 const exampleShorthand = "/en-US/docs/Web/HTML/Element/div";
 
-const { argv } = require("yargs")
+const { argv } = yargs
   .parserConfiguration({ "boolean-negation": false })
   .usage("Usage: $0 <url>")
   .example(`$0 ${examplePage}`, "scrape a page and all its subpages")
@@ -39,7 +40,9 @@ const { argv } = require("yargs")
   .alias("v", "verbose")
 
   .demandCommand(1, 1, "A URL is required", "Too many arguments")
-  .boolean(["n", "no-subpages", "q", "s", "v"]);
+  .boolean(["n", "no-subpages", "q", "s", "v"])
+
+  .wrap(yargs.terminalWidth());
 
 const processor = rehype()
   .use([require("./plugins/kumascript-macros")])

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -69,10 +69,15 @@ async function run() {
   });
   const processed = await Promise.all(files);
 
-  const reporter = argv.summary ? summaryReporter : fileReporter;
   console.log(
-    reporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
+    fileReporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
   );
+
+  if (argv.summary) {
+    console.log(
+      summaryReporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
+    );
+  }
 }
 
 async function fetchTree(input) {

--- a/scripts/scraper-ng/rules/html-require-macros.js
+++ b/scripts/scraper-ng/rules/html-require-macros.js
@@ -20,7 +20,7 @@ function requireMacros(tree, file, required = []) {
   );
 
   for (const macro of required) {
-    file.message(`One or more ${macro} macro calls required but not found`);
+    file.message(`${macro} macro call required but not found`);
   }
 }
 

--- a/scripts/scraper-ng/rules/html-warn-macros.js
+++ b/scripts/scraper-ng/rules/html-warn-macros.js
@@ -5,7 +5,9 @@ const visit = require("unist-util-visit-parents");
  * `allowedMacros`)
  */
 function attacher(allowedMacros) {
-  allowedMacros = Array.isArray(allowedMacros) ? allowedMacros : [];
+  allowedMacros = Array.isArray(allowedMacros)
+    ? allowedMacros.map(normalizeMacroName)
+    : [];
 
   return function warnOnMacros(tree, file) {
     visit(
@@ -14,7 +16,7 @@ function attacher(allowedMacros) {
         node.type === "text" &&
         node.data &&
         node.data.macroName &&
-        !allowedMacros.includes(node.data.macroName),
+        !allowedMacros.includes(normalizeMacroName(node.data.macroName)),
       (node, ancestors) => {
         // Because macro nodes are generated, they don't have position
         // information. The parent node's position is used instead.

--- a/scripts/scraper-ng/rules/html-warn-macros.js
+++ b/scripts/scraper-ng/rules/html-warn-macros.js
@@ -20,13 +20,29 @@ function attacher(allowedMacros) {
         // information. The parent node's position is used instead.
         const parent = ancestors[ancestors.length - 1];
         const message = file.message(`Macro: ${node.data.macroName}`, parent);
-        message.ruleId = `html-warn-on-macros:${node.data.macroName}`;
+        message.ruleId = `html-warn-on-macros:${normalizeMacroName(
+          node.data.macroName
+        )}`;
         message.note = `With arguments: ${JSON.stringify(
           node.data.macroParams
         )}`;
       }
     );
   };
+}
+
+/**
+ * Make the case of a macro consistent with other possible invocations of this
+ * macro.
+ *
+ * The right thing to do probably involves finding out the canonical name of
+ * every macro, but for now, this just lower cases the name.
+ *
+ * @param {String} name - a macro name
+ * @returns {String}
+ */
+function normalizeMacroName(name) {
+  return name.toLowerCase();
 }
 
 module.exports = attacher;

--- a/scripts/scraper-ng/rules/html-warn-macros.js
+++ b/scripts/scraper-ng/rules/html-warn-macros.js
@@ -1,28 +1,32 @@
-const rule = require("unified-lint-rule");
 const visit = require("unist-util-visit-parents");
 
 /**
  * Issue a warning for each macro call (except for the array of macro names in
  * `allowedMacros`)
  */
-function warnOnMacros(tree, file, allowedMacros) {
+function attacher(allowedMacros) {
   allowedMacros = Array.isArray(allowedMacros) ? allowedMacros : [];
 
-  visit(
-    tree,
-    node =>
-      node.type === "text" &&
-      node.data &&
-      node.data.macroName &&
-      !allowedMacros.includes(node.data.macroName),
-    (node, ancestors) => {
-      // Because macro nodes are generated, they don't have position
-      // information. The parent node's position is used instead.
-      const parent = ancestors[ancestors.length - 1];
-      const message = file.message(`Macro: ${node.data.macroName}`, parent);
-      message.note = `With arguments: ${JSON.stringify(node.data.macroParams)}`;
-    }
-  );
+  return function warnOnMacros(tree, file) {
+    visit(
+      tree,
+      node =>
+        node.type === "text" &&
+        node.data &&
+        node.data.macroName &&
+        !allowedMacros.includes(node.data.macroName),
+      (node, ancestors) => {
+        // Because macro nodes are generated, they don't have position
+        // information. The parent node's position is used instead.
+        const parent = ancestors[ancestors.length - 1];
+        const message = file.message(`Macro: ${node.data.macroName}`, parent);
+        message.ruleId = `html-warn-on-macros:${node.data.macroName}`;
+        message.note = `With arguments: ${JSON.stringify(
+          node.data.macroParams
+        )}`;
+      }
+    );
+  };
 }
 
-module.exports = rule("html-warn-on-macros", warnOnMacros);
+module.exports = attacher;

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -5,7 +5,6 @@ const statistics = require("vfile-statistics");
  * Generate a summary report of VFile messages.
  *
  * @param {(VFile|Array.<VFile>|Error)} files - `VFile`, `Array.<VFile>`, or `Error`
- * @param {Object} options
  * @returns A string
  */
 function reporter(files) {

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -1,0 +1,34 @@
+/**
+ * Generate a summary report of the messages for the given `VFile`, `Array.<VFile>`, or `Error`.
+ *
+ * @param {(VFile|Array.<VFile>|Error)} files - `VFile`, `Array.<VFile>`, or `Error`
+ * @param {Object} options
+ * @returns A string
+ */
+function reporter(files, options) {
+  const settings = options || {};
+
+  // Undefined or `null`
+  if (!files) {
+    return "";
+  }
+
+  // A single Error
+  if ("name" in files && "message" in files) {
+    throw Error("Not implemented");
+  }
+
+  // A single file
+  if (!("length" in files)) {
+    files = [files];
+  }
+
+  // Do the things with the files
+  return summarize(files);
+}
+
+function summarize(files) {
+  throw Error("Not implemented");
+}
+
+module.exports = reporter;

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -14,7 +14,7 @@ function reporter(files) {
   }
 
   // A single Error
-  if ("name" in files && "message" in files) {
+  if (files instanceof Error) {
     // We might want to implement the full reporter API at some point, but not now.
     throw Error("Not implemented");
   }

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -51,7 +51,7 @@ function summarize(files) {
     rule.map((field, columnNumber) => field.padEnd(maxWidths[columnNumber]))
   );
 
-  const prologue = ["", chalk`{yellow {underline Summary}}`];
+  const prologue = ["", chalk.yellow(chalk.underline("Summary"))];
   const body = paddedFields.map(field => field.join("  "));
   const epilogue = ["", formatStats(files, body)];
 

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -5,7 +5,7 @@ const statistics = require("vfile-statistics");
  * Generate a summary report of VFile messages.
  *
  * @param {(VFile|Array.<VFile>|Error)} files - `VFile`, `Array.<VFile>`, or `Error`
- * @returns A string
+ * @returns {String} the summary as a string
  */
 function reporter(files) {
   // Undefined or `null`
@@ -62,7 +62,9 @@ function summarize(files) {
  * Count each message ruleId found in the array of vfiles.
  *
  * @param {Array.<VFile>} files
- * @returns
+ * @returns {Object} An object such that each key is a `ruleId` and each value
+ * is an object consisting of a `count` (an integer), a VFile message `reason`,
+ * and whether the message is `fatal`.
  */
 function countRules(files) {
   const rules = {};
@@ -88,7 +90,7 @@ function countRules(files) {
  * Make an array of human-readable strings describing the rule and its count.
  *
  * @param {Object}
- * @returns
+ * @returns {Array.<String>} An array of strings: a VFile message reason, a count and severity, and a ruleId.
  */
 function formatRule({ count, fatal, reason, ruleId }) {
   const s = plural(count);
@@ -99,9 +101,9 @@ function formatRule({ count, fatal, reason, ruleId }) {
 /**
  * Make a human-readable string of statistics from the summary.
  *
- * @param {Array.<VFile>} files
- * @param {Array.<String>} summaryLines
- * @returns {String}
+ * @param {Array.<VFile>} files - an array of VFiles
+ * @param {Array.<String>} summaryLines - an array of lines from the summary
+ * @returns {String} a string of statistics
  */
 function formatStats(files, summaryLines) {
   const { fatal, nonfatal, total } = statistics(files);

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -1,3 +1,5 @@
+const chalk = require("chalk");
+
 /**
  * Generate a summary report of the messages for the given `VFile`, `Array.<VFile>`, or `Error`.
  *
@@ -69,9 +71,11 @@ function summarize(files) {
 }
 
 function humanize({ count, fatal, reason, ruleId }) {
-  const severity = fatal ? "error" : "warning";
   const plural = count > 1 ? "s" : "";
-  return [`${reason}`, `${count} ${severity}${plural}`, `${ruleId}`];
+  const severity = fatal
+    ? chalk.red(`error${plural}`)
+    : chalk.yellow(`warning${plural}`);
+  return [reason, `${count} ${severity}`, ruleId];
 }
 
 module.exports = reporter;

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -20,7 +20,7 @@ function reporter(files) {
   }
 
   // A single file
-  if (!("length" in files)) {
+  if (!Array.isArray(files)) {
     files = [files];
   }
 

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -91,10 +91,8 @@ function countRules(files) {
  * @returns
  */
 function formatRule({ count, fatal, reason, ruleId }) {
-  const plural = count > 1 ? "s" : "";
-  const severity = fatal
-    ? chalk.red(`error${plural}`)
-    : chalk.yellow(`warning${plural}`);
+  const s = plural(count);
+  const severity = fatal ? chalk.red(`error${s}`) : chalk.yellow(`warning${s}`);
   return [reason, `${count} ${severity}`, ruleId];
 }
 
@@ -107,8 +105,6 @@ function formatRule({ count, fatal, reason, ruleId }) {
  */
 function formatStats(files, summaryLines) {
   const { fatal, nonfatal, total } = statistics(files);
-
-  const plural = num => (num === 1 ? "" : "s");
 
   const notices = total > 0 ? `${total} notice${plural(total)}` : "";
   const errors =
@@ -126,6 +122,16 @@ function formatStats(files, summaryLines) {
     parenthetical,
     `in ${files.length} file${plural(files.length)}`
   ].join(" ");
+}
+
+/**
+ * Return an "s" or an empty string, depending on the value of `num`.
+ *
+ * @param {Number} num
+ * @returns {String} "s" or an empty string
+ */
+function plural(num) {
+  return num === 1 ? "" : "s";
 }
 
 module.exports = reporter;

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -53,7 +53,7 @@ function summarize(files) {
     rule.map((field, columnNumber) => field.padEnd(maxWidths[columnNumber]))
   );
 
-  const prologue = [""];
+  const prologue = ["", chalk`{yellow {underline Summary}}`];
   const body = paddedFields.map(field => field.join("  "));
   const epilogue = ["", formatStats(files, body)];
 

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -5,9 +5,7 @@
  * @param {Object} options
  * @returns A string
  */
-function reporter(files, options) {
-  const settings = options || {};
-
+function reporter(files) {
   // Undefined or `null`
   if (!files) {
     return "";
@@ -28,7 +26,52 @@ function reporter(files, options) {
 }
 
 function summarize(files) {
-  throw Error("Not implemented");
+  const rules = {};
+
+  for (const file of files) {
+    for (const message of file.messages) {
+      if (rules[message.ruleId]) {
+        rules[message.ruleId].count += 1;
+      } else {
+        rules[message.ruleId] = {
+          reason: message.reason,
+          fatal: message.fatal,
+          count: 1
+        };
+      }
+    }
+  }
+
+  const rulesArray = Object.entries(rules)
+    .map(([ruleId, details]) => ({
+      ruleId,
+      ...details
+    }))
+    .sort((a, b) => a.count - b.count)
+    .reverse();
+
+  const lineParts = rulesArray.map(humanize);
+
+  const columns = lineParts[0].length;
+  const partWidths = lineParts.map(parts => parts.map(part => part.length));
+  const maxWidths = partWidths.reduce(
+    (prev, curr) => prev.map((number, index) => Math.max(number, curr[index])),
+    Array(columns).fill(0)
+  );
+
+  const paddedLineParts = lineParts.map(line =>
+    line.map((part, columnNumber) => part.padEnd(maxWidths[columnNumber]))
+  );
+
+  // TODO: Add stats at the end, with number of pages, etc.
+
+  return paddedLineParts.map(line => line.join("\t")).join("\n");
+}
+
+function humanize({ count, fatal, reason, ruleId }) {
+  const severity = fatal ? "error" : "warning";
+  const plural = count > 1 ? "s" : "";
+  return [`${reason}`, `${count} ${severity}${plural}`, `${ruleId}`];
 }
 
 module.exports = reporter;

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -36,8 +36,7 @@ function summarize(files) {
       ruleId,
       ...details
     }))
-    .sort((a, b) => a.count - b.count)
-    .reverse();
+    .sort((a, b) => b.count - a.count);
 
   const ruleFields = sortedRules.map(formatRule);
 


### PR DESCRIPTION
This PR provides a general summary view of messages across the entire tree linted by `/scripts/scraper-ng`. With the new `-s/--summary` option, you can generate a report like this:

```
$ node ./scripts/scraper-ng /en-US/docs/Web/HTML/Element --summary -q
Preparing to lint 164 pages…

Macro: HTMLElement                        1736 warnings  html-warn-on-macros:htmlelement            
Macro: HTMLAttrDef                        586 warnings   html-warn-on-macros:htmlattrdef            
Macro: HTMLAttrxRef                       540 warnings   html-warn-on-macros:htmlattrxref           
Macro: DOMxRef                            466 warnings   html-warn-on-macros:domxref                
Macro: SpecName                           378 warnings   html-warn-on-macros:specname               
Macro: CSSxRef                            370 warnings   html-warn-on-macros:cssxref                
Macro: Spec2                              366 warnings   html-warn-on-macros:spec2                  
Macro: EmbedLiveSample                    309 warnings   html-warn-on-macros:embedlivesample        
Macro: anch                               297 warnings   html-warn-on-macros:anch                   
Macro: Glossary                           161 warnings   html-warn-on-macros:glossary               
Macro: ARIARole                           126 warnings   html-warn-on-macros:ariarole               
Macro: EmbedInteractiveExample            114 warnings   html-warn-on-macros:embedinteractiveexample
Macro: HTMLVersionInline                  73 warnings    html-warn-on-macros:htmlversioninline      
Macro: Obsolete_Inline                    60 warnings    html-warn-on-macros:obsolete_inline        
Macro: page                               53 warnings    html-warn-on-macros:page                   
Macro: Event                              41 warnings    html-warn-on-macros:event                  
Macro: Deprecated_inline                  20 warnings    html-warn-on-macros:deprecated_inline      
Macro: HTTPHeader                         17 warnings    html-warn-on-macros:httpheader             
Macro: HTMLRefTable                       15 warnings    html-warn-on-macros:htmlreftable           
Macro: SectionOnPage                      14 warnings    html-warn-on-macros:sectiononpage          
Macro: bug                                13 warnings    html-warn-on-macros:bug                    
Macro: jsxref                             11 warnings    html-warn-on-macros:jsxref                 
Macro: interwiki                          9 warnings     html-warn-on-macros:interwiki              
Macro: HTTPMethod                         8 warnings     html-warn-on-macros:httpmethod             
Macro: unimplemented_inline               7 warnings     html-warn-on-macros:unimplemented_inline   
Macro: obsolete_header                    5 warnings     html-warn-on-macros:obsolete_header        
Macro: RFC                                4 warnings     html-warn-on-macros:rfc                    
Macro: Gecko                              3 warnings     html-warn-on-macros:gecko                  
Macro: SVGElement                         3 warnings     html-warn-on-macros:svgelement             
Macro: HTMLRef                            2 warnings     html-warn-on-macros:htmlref                
Macro: MathMLElement                      2 warnings     html-warn-on-macros:mathmlelement          
Compat macro call required but not found  2 errors       html-require-macros                        
Macro: Note                               1 warning      html-warn-on-macros:note                   
Macro: Deprecated_Header                  1 warning      html-warn-on-macros:deprecated_header      
Macro: EmbedGHLiveSample                  1 warning      html-warn-on-macros:embedghlivesample      
Macro: HTMLSidebar                        1 warning      html-warn-on-macros:htmlsidebar            

36 notice types (5815 notices, ✖ 2 errors, ⚠ 5813 warnings) in 164 files
```

Now you can pretty quickly get a count of all the macros used in a given tree. For instance, now I know that the Element pages use the `cssxref` macro 370 times.

For this PR to satisfy https://github.com/mdn/sprints/issues/2519, I had to make some unexpected changes to `html-warn-macros`. Previously, I used the `unified-lint-rule` wrapper; unfortunately, this doesn't let me uniquely identify macro calls easily. I unwrapped it to provide a unique `ruleId` for each macro.

Similarly, to make it easier to follow the CLI setup, I reordered things while documenting the new `--summary` option. Because of changes like these, you might find it easier to follow the PR commits sequentially.

In terms of feedback, I'm open to anything, as usual, but I'm also interested in these questions:

* Does the reporter code itself make sense? The prior art, [`vfile-reporter`](https://github.com/vfile/vfile-reporter/blob/master/index.js), is not the easiest thing to follow and I tried to do a little better; I'm not sure I succeeded.
* Is the CLI flag a sensible way to switch to this summary mode? Would you prefer if this were the default instead?
* Is it OK that I introduced a new dependency, [`chalk`](https://www.npmjs.com/package/chalk), to color output? We use this library in BCD, but it's new to this project. I didn't really look closely at alternatives.

Thanks for looking this over!