### PR TITLE
Normalize macro names in linting

### DIFF
--- a/scripts/scraper-ng/normalize-macro-name.js
+++ b/scripts/scraper-ng/normalize-macro-name.js
@@ -1,0 +1,15 @@
+/**
+ * Make the case of a macro consistent with other possible invocations of this
+ * macro.
+ *
+ * The right thing to do probably involves finding out the canonical name of
+ * every macro, but for now, this just lower cases the name.
+ *
+ * @param {String} name - a macro name
+ * @returns {String}
+ */
+function normalizeMacroName(name) {
+  return name.toLowerCase();
+}
+
+module.exports = normalizeMacroName;

--- a/scripts/scraper-ng/plugins/kumascript-macros.js
+++ b/scripts/scraper-ng/plugins/kumascript-macros.js
@@ -1,5 +1,7 @@
 const findAndReplace = require("hast-util-find-and-replace");
 
+const normalizeMacroName = require("../normalize-macro-name");
+
 /*
  * Find KumaScript macros in text literal nodes and put them in separate nodes
  * with data about the macro calls.
@@ -11,13 +13,15 @@ function kumascriptMacrosPlugin() {
   return function transformer(tree) {
     findAndReplace(tree, macroRegex, match => {
       const groups = match.match(new RegExp(macroRegex.source, ""));
-      const macroName = groups[1];
+      const macroCall = groups[1];
+      const macroName = normalizeMacroName(macroCall);
       const macroParams = processParams(groups[2]);
 
       return {
         type: "text",
         value: match,
         data: {
+          macroCall,
           macroName,
           macroParams
         }

--- a/scripts/scraper-ng/rules/html-require-macros.js
+++ b/scripts/scraper-ng/rules/html-require-macros.js
@@ -1,6 +1,8 @@
 const rule = require("unified-lint-rule");
 const visit = require("unist-util-visit");
 
+const normalizeMacroName = require("../normalize-macro-name");
+
 /**
  * Require one or more named macros.
  */
@@ -10,9 +12,12 @@ function requireMacros(tree, file, required = []) {
     node =>
       node.type === "text" &&
       node.data &&
-      required.includes(node.data.macroName),
+      required.map(normalizeMacroName).includes(node.data.macroName),
     node => {
-      required = required.filter(macro => node.data.macroName !== macro);
+      required = required.filter(
+        macro => node.data.macroName !== normalizeMacroName(macro)
+      );
+
       if (!required.length) {
         return visit.EXIT;
       }

--- a/scripts/scraper-ng/rules/html-warn-macros.js
+++ b/scripts/scraper-ng/rules/html-warn-macros.js
@@ -1,5 +1,7 @@
 const visit = require("unist-util-visit-parents");
 
+const normalizeMacroName = require("../normalize-macro-name");
+
 /**
  * Issue a warning for each macro call (except for the array of macro names in
  * `allowedMacros`)
@@ -16,35 +18,19 @@ function attacher(allowedMacros) {
         node.type === "text" &&
         node.data &&
         node.data.macroName &&
-        !allowedMacros.includes(normalizeMacroName(node.data.macroName)),
+        !allowedMacros.includes(node.data.macroName),
       (node, ancestors) => {
         // Because macro nodes are generated, they don't have position
         // information. The parent node's position is used instead.
         const parent = ancestors[ancestors.length - 1];
-        const message = file.message(`Macro: ${node.data.macroName}`, parent);
-        message.ruleId = `html-warn-on-macros:${normalizeMacroName(
-          node.data.macroName
-        )}`;
+        const message = file.message(`Macro: ${node.data.macroCall}`, parent);
+        message.ruleId = `html-warn-on-macros:${node.data.macroName}`;
         message.note = `With arguments: ${JSON.stringify(
           node.data.macroParams
         )}`;
       }
     );
   };
-}
-
-/**
- * Make the case of a macro consistent with other possible invocations of this
- * macro.
- *
- * The right thing to do probably involves finding out the canonical name of
- * every macro, but for now, this just lower cases the name.
- *
- * @param {String} name - a macro name
- * @returns {String}
- */
-function normalizeMacroName(name) {
-  return name.toLowerCase();
 }
 
 module.exports = attacher;


### PR DESCRIPTION
This is my attempt to handle macro name case better. I've distinguished a macro's _name_ (lower case) from the _call_ used in the linted page (whatever case the author of the page actually used). Hopefully this approach will let the linter messages accurately reflect the source, while matching macro names case insensitively.

Fixes #270.