### PR TITLE
Fixing incorrect glob patterns (used for linting / prettier-ing) + unseen linting errors 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "scrape-mdn": "node scripts/scraper/scrape-mdn.js",
         "ci-checks": "node scripts/ci/git.js",
         "mdn-sitemap-compare": "node scripts/linting/mdn-sitemap-compare.js",
-        "spell-md-en": "mdspell -a -n -r -x --en-us 'content/en-US/**/!(*contributors).md'",
+        "spell-md-en": "mdspell -a -n -r -x --en-us \"content/en-US/**/!(*contributors).md\"",
         "test": "npm run lint-code && npm run lint-md && npm run spell-md-en"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "url": "https://github.com/mdn/stumptown-content/issues"
     },
     "scripts": {
-        "prettier-check": "prettier --check scripts/**/*.js **/*.yaml",
-        "prettier-format": "prettier --write scripts/**/*.js **/*.yaml",
+        "prettier-check": "prettier --check \"scripts/**/*.js\" \"**/*.yaml\"",
+        "prettier-format": "prettier --write \"scripts/**/*.js\" \"**/*.yaml\"",
         "lint-md": "node scripts/linter",
         "lint-code": "eslint \"scripts/**/*.js\" && npm run prettier-check",
         "build-json": "node scripts/build-json/build-json.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "prettier-check": "prettier --check scripts/**/*.js **/*.yaml",
         "prettier-format": "prettier --write scripts/**/*.js **/*.yaml",
         "lint-md": "node scripts/linter",
-        "lint-code": "eslint scripts/**/*.js && npm run prettier-check",
+        "lint-code": "eslint \"scripts/**/*.js\" && npm run prettier-check",
         "build-json": "node scripts/build-json/build-json.js",
         "scrape-mdn": "node scripts/scraper/scrape-mdn.js",
         "ci-checks": "node scripts/ci/git.js",

--- a/scripts/linter/plugins/valid-specs.js
+++ b/scripts/linter/plugins/valid-specs.js
@@ -1,11 +1,13 @@
 const visit = require("unist-util-visit");
 const yaml = require("js-yaml");
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 const ROOT = path.join(__dirname, "..", "..", "..");
-const dataDir = path.resolve(ROOT, 'content', 'data');
-const specMap = yaml.safeLoad(fs.readFileSync(path.join(dataDir, 'specifications.yaml'), 'utf8'));
+const dataDir = path.resolve(ROOT, "content", "data");
+const specMap = yaml.safeLoad(
+  fs.readFileSync(path.join(dataDir, "specifications.yaml"), "utf8")
+);
 
 const ruleId = "stumptown-linter:valid-specifications";
 const specURLRegex = new RegExp("^http(s)?://[^#]+#.+");
@@ -14,35 +16,43 @@ const specURLRegex = new RegExp("^http(s)?://[^#]+#.+");
  * Check the front-matter for valid `specifications`
  */
 function attacher() {
-    return function transformer(tree, file) {
-        visit(tree, "yaml", node => {
-            let specs = node.data.yaml.specifications;
-            // specifications are optional
-            if (specs) {
-                // specifications can be single url or array of urls
-                if (!Array.isArray(specs)) {
-                    specs = [specs];
-                }
-                specs.forEach(spec => {
-                    // "non-standard" is a special string indicating that there is no spec. Allow this one.
-                    if (spec === 'non-standard') {
-                      return;
-                    }
-                    // Any other strings should be URLs and provide a deep link to a spec section.
-                    if (!specURLRegex.test(spec)) {
-                        const message = file.message(`"${spec}" is not a valid specification link (anchored deep link required).`, node, ruleId);
-                        message.fatal = true;
-                    }
-                    // Spec URLs should be allow-listed, so that we don't list any outdated specs.
-                    const allowedSpecs = Object.keys(specMap);
-                    if (!allowedSpecs.some(key => spec.includes(key))) {
-                        const message = file.message(`Domain for "${spec}" not found in data/specifications.yaml`, node, ruleId);
-                        message.fatal = true;
-                    }
-                });
-            }
+  return function transformer(tree, file) {
+    visit(tree, "yaml", node => {
+      let specs = node.data.yaml.specifications;
+      // specifications are optional
+      if (specs) {
+        // specifications can be single url or array of urls
+        if (!Array.isArray(specs)) {
+          specs = [specs];
+        }
+        specs.forEach(spec => {
+          // "non-standard" is a special string indicating that there is no spec. Allow this one.
+          if (spec === "non-standard") {
+            return;
+          }
+          // Any other strings should be URLs and provide a deep link to a spec section.
+          if (!specURLRegex.test(spec)) {
+            const message = file.message(
+              `"${spec}" is not a valid specification link (anchored deep link required).`,
+              node,
+              ruleId
+            );
+            message.fatal = true;
+          }
+          // Spec URLs should be allow-listed, so that we don't list any outdated specs.
+          const allowedSpecs = Object.keys(specMap);
+          if (!allowedSpecs.some(key => spec.includes(key))) {
+            const message = file.message(
+              `Domain for "${spec}" not found in data/specifications.yaml`,
+              node,
+              ruleId
+            );
+            message.fatal = true;
+          }
         });
-    };
+      }
+    });
+  };
 }
 
 module.exports = attacher;

--- a/scripts/scraper/process-macros/process-interactive-example.js
+++ b/scripts/scraper/process-macros/process-interactive-example.js
@@ -23,9 +23,7 @@ function processInteractiveExample(htmlWithMacroCalls, result) {
     htmlWithMacroCalls
   );
   if (macroCalls[0]) {
-    const url = `https://interactive-examples.mdn.mozilla.net/${
-      macroCalls[0][0]
-    }`;
+    const url = `https://interactive-examples.mdn.mozilla.net/${macroCalls[0][0]}`;
     const height = getInteractiveExampleHeight(macroCalls[0][1]);
     result.frontMatter += `interactive_example:\n    url: ${url}\n    height: ${height}\n`;
   }

--- a/scripts/scraper/process-macros/process-live-samples.js
+++ b/scripts/scraper/process-macros/process-live-samples.js
@@ -1,10 +1,7 @@
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom;
 const fs = require("fs");
 const path = require("path");
 
 const { toMarkdown } = require("../to-markdown.js");
-const { removeTitleAttributes } = require("../clean-html.js");
 const { extractMacroCalls } = require("./extract-macro-calls");
 
 /**


### PR DESCRIPTION
Previous glob patterns were either misleading (not covering all the code on my Ubuntu) or failing on Windows.
I added (escaped) double-quotes so that Node takes care of the expansion (instead of a specific shell which may vary).

Linting errors which went unseen so far were also fixed:
* scripts/scraper/process-macros/process-interactive-example.js (lint) - Unused variables only
* scripts/linter/plugins/valid-specs.js (Prettier)
* scripts/scraper/process-macros/process-interactive-example.js (Prettier)

Shamelessly poking @ddbeck & @peterbe based on history.

P.S. got that "glob expansion" bug on some other project aaaand spent hours spotting it
P.P.S https://eslint.org/docs/user-guide/command-line-interface (note about glob expansion just before "Options")