### PR TITLE
Explore matching pages to recipes

### DIFF
--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -47,6 +47,7 @@ const { argv } = yargs
 const processor = rehype()
   .use([
     require("./plugins/kuma-metadata"),
+    require("./plugins/annotate-recipe"),
     require("./plugins/kumascript-macros")
   ])
   .use([require("./preset")]);

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -45,7 +45,10 @@ const { argv } = yargs
   .wrap(yargs.terminalWidth());
 
 const processor = rehype()
-  .use([require("./plugins/kumascript-macros")])
+  .use([
+    require("./plugins/kuma-metadata"),
+    require("./plugins/kumascript-macros")
+  ])
   .use([require("./preset")]);
 // TODO: add YAML frontmatter insertion
 

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -47,7 +47,7 @@ const { argv } = yargs
 const processor = rehype()
   .use([
     require("./plugins/kuma-metadata"),
-    require("./plugins/annotate-recipe"),
+    require("./plugins/identify-recipes"),
     require("./plugins/kumascript-macros")
   ])
   .use([require("./preset")]);

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -1,9 +1,9 @@
-const { RateLimit } = require("async-sema");
 const fetch = require("node-fetch");
 const fileReporter = require("vfile-reporter");
 const rehype = require("rehype");
 const yargs = require("yargs");
 
+const limiter = require("./rate-limiter");
 const mdnUrl = require("./mdn-url");
 const summaryReporter = require("./vfile-reporter-summary");
 const toVFile = require("./url-to-vfile");
@@ -56,7 +56,6 @@ async function run() {
   console.log(`Preparing to lint ${urls.length} pages…`);
   await new Promise(resolve => setTimeout(resolve, 2000)); // give 2 seconds to gracefully bail out
 
-  const limiter = RateLimit(4, { uniformDistribution: true });
   const files = urls.map(async url => {
     await limiter();
     if (!argv.quiet) console.log(`Fetching ${url}`);

--- a/scripts/scraper-ng/plugins/annotate-recipe.js
+++ b/scripts/scraper-ng/plugins/annotate-recipe.js
@@ -69,24 +69,13 @@ function recipe(name) {
 }
 
 /**
- * Check if some tags contains some other tags.
- *
- * @param {Set<String>} actualTags
- * @param {Set<String} expectedTags
- * @returns {Boolean} `true` or `false`
- */
-function hasAll(actualTags, expectedTags) {
-  return isSuperset(actualTags, expectedTags);
-}
-
-/**
- * Check if a set is a subset of another set.
+ * Check if a set of tags contains some other set of tags.
  *
  * @param {Set} set
  * @param {Set} subset
  * @returns {Boolean} `true` or `false`
  */
-function isSuperset(set, subset) {
+function hasAll(set, subset) {
   for (let elem of subset) {
     if (!set.has(elem)) {
       return false;

--- a/scripts/scraper-ng/plugins/annotate-recipe.js
+++ b/scripts/scraper-ng/plugins/annotate-recipe.js
@@ -1,0 +1,98 @@
+const path = require("path");
+
+const signatures = [
+  {
+    recipePath: recipe("javascript-class"),
+    conditions: {
+      tags: ["JavaScript", "Class"]
+    }
+  },
+  {
+    recipePath: recipe("javascript-constructor"),
+    conditions: {
+      tags: ["JavaScript", "Constructor"]
+    }
+  },
+  {
+    recipePath: recipe("javascript-error"),
+    conditions: {
+      tags: ["JavaScript", "Error"]
+    }
+  },
+  {
+    recipePath: recipe("javascript-method"),
+    conditions: {
+      tags: ["JavaScript", "Method"]
+    }
+  },
+  {
+    recipePath: recipe("javascript-property"),
+    conditions: {
+      tags: ["JavaScript", "Property"]
+    }
+  }
+];
+
+/**
+ * Add a path to a recipe file to `VFile.data.recipePath`.
+ *
+ * @returns A unified transformer.
+ */
+function annotateRecipePlugin() {
+  return function transformer(tree, file) {
+    const tagSet = new Set(file.data.tags);
+
+    for (const { recipePath, conditions } of signatures) {
+      if (hasAll(tagSet, conditions.tags)) {
+        file.data.recipePath = recipePath;
+        return;
+      }
+    }
+
+    const message = file.message(
+      "No recipe matched this page",
+      undefined,
+      "require-recipe"
+    );
+    message.fatal = true;
+  };
+}
+
+/**
+ * Convert a recipe name to a recipe file path.
+ *
+ * @param {String} name - the name of a recipe, without an extension
+ * @returns {String} An absolute path to a recipe file
+ */
+function recipe(name) {
+  return path.resolve(__dirname, "../../recipes", name + ".yaml");
+}
+
+/**
+ * Check if some tags contains some other tags.
+ *
+ * @param {Set<String>} actualTags
+ * @param {Set<String} expectedTags
+ * @returns {Boolean} `true` or `false`
+ */
+function hasAll(actualTags, expectedTags) {
+  return isSuperset(actualTags, expectedTags);
+}
+
+/**
+ * Check if a set is a subset of another set.
+ *
+ * @param {Set} set
+ * @param {Set} subset
+ * @returns {Boolean} `true` or `false`
+ */
+function isSuperset(set, subset) {
+  for (let elem of subset) {
+    if (!set.has(elem)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = annotateRecipePlugin;

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -38,7 +38,7 @@ const signatures = [
  *
  * @returns A unified transformer.
  */
-function annotateRecipePlugin() {
+function identifyRecipesPlugin() {
   return function transformer(tree, file) {
     const tagSet = new Set(file.data.tags);
 
@@ -84,4 +84,4 @@ function hasAll(set, subset) {
   return true;
 }
 
-module.exports = annotateRecipePlugin;
+module.exports = identifyRecipesPlugin;

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -16,7 +16,7 @@ const signatures = [
   {
     recipePath: recipe("javascript-error"),
     conditions: {
-      tags: ["JavaScript", "Error"]
+      tags: ["JavaScript", "Error", "Constructor"]
     }
   },
   {

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -41,20 +41,19 @@ const signatures = [
 function identifyRecipesPlugin() {
   return function transformer(tree, file) {
     const tagSet = new Set(file.data.tags);
+    const recipes = [];
 
     for (const { recipePath, conditions } of signatures) {
       if (hasAll(tagSet, conditions.tags)) {
-        file.data.recipePath = recipePath;
-        return;
+        recipes.push(recipePath);
       }
     }
 
-    const message = file.message(
-      "No recipe matched this page",
-      undefined,
-      "require-recipe"
-    );
-    message.fatal = true;
+    if (recipes.length === 1) {
+      file.data.recipePath = recipes[0];
+    } else if (recipes.length > 1) {
+      file.data.recipePath = recipes;
+    }
   };
 }
 

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -64,7 +64,7 @@ function identifyRecipesPlugin() {
  * @returns {String} An absolute path to a recipe file
  */
 function recipe(name) {
-  return path.resolve(__dirname, "../../recipes", name + ".yaml");
+  return path.resolve(__dirname, "../../../recipes", name + ".yaml");
 }
 
 /**

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -16,7 +16,7 @@ const signatures = [
   {
     recipePath: recipe("javascript-error"),
     conditions: {
-      tags: ["JavaScript", "Error", "Constructor"]
+      tags: ["JavaScript", "Errors"]
     }
   },
   {

--- a/scripts/scraper-ng/plugins/kuma-metadata.js
+++ b/scripts/scraper-ng/plugins/kuma-metadata.js
@@ -2,6 +2,14 @@ const fetch = require("node-fetch");
 
 const limiter = require("../rate-limiter");
 
+/**
+ * Add MDN `$json` data to the VFile's `data` attribute:
+ *
+ * - `VFile.data.tags` - An array of tags for the page
+ * - `VFile.data.title` - The title of the page
+ *
+ * @returns {Function} A unified plugin
+ */
 function kumaMetadataPlugin() {
   return async function transformer(tree, file) {
     try {

--- a/scripts/scraper-ng/plugins/kuma-metadata.js
+++ b/scripts/scraper-ng/plugins/kuma-metadata.js
@@ -8,7 +8,7 @@ const limiter = require("../rate-limiter");
  * - `VFile.data.tags` - An array of tags for the page
  * - `VFile.data.title` - The title of the page
  *
- * @returns {Function} A unified plugin
+ * @returns {Function} A unified transformer
  */
 function kumaMetadataPlugin() {
   return async function transformer(tree, file) {
@@ -25,6 +25,12 @@ function kumaMetadataPlugin() {
   };
 }
 
+/**
+ * Fetch the `$json` data for an MDN URL.
+ *
+ * @param {URL} - an MDN URL
+ * @returns {Promise} - A promise for the `$json` URL's JSON data
+ */
 async function fetchJson(url) {
   await limiter;
   const response = await fetch(toJson(url));
@@ -37,6 +43,12 @@ async function fetchJson(url) {
   return response.json();
 }
 
+/**
+ * Append `$json` to a URL.
+ *
+ * @param {URL} url
+ * @returns {URL} A URL
+ */
 function toJson(url) {
   const jsonUrl = new URL(url);
   jsonUrl.pathname += "$json";

--- a/scripts/scraper-ng/plugins/kuma-metadata.js
+++ b/scripts/scraper-ng/plugins/kuma-metadata.js
@@ -1,0 +1,38 @@
+const fetch = require("node-fetch");
+
+const limiter = require("../rate-limiter");
+
+function kumaMetadataPlugin() {
+  return async function transformer(tree, file) {
+    try {
+      const { title, tags } = await fetchJson(file.data.url);
+      // eslint-disable-next-line require-atomic-updates
+      file.data.tags = tags;
+      // eslint-disable-next-line require-atomic-updates
+      file.data.title = title;
+    } catch (err) {
+      const message = file.message(err.message);
+      message.fatal = true;
+    }
+  };
+}
+
+async function fetchJson(url) {
+  await limiter;
+  const response = await fetch(toJson(url));
+  if (!response.ok) {
+    throw Error(
+      `Could not fetch page info from ${response.url} (${response.status} ${response.statusText})`
+    );
+  }
+
+  return response.json();
+}
+
+function toJson(url) {
+  const jsonUrl = new URL(url);
+  jsonUrl.pathname += "$json";
+  return jsonUrl;
+}
+
+module.exports = kumaMetadataPlugin;

--- a/scripts/scraper-ng/preset.js
+++ b/scripts/scraper-ng/preset.js
@@ -4,10 +4,13 @@ const requiredMacros = ["Compat"];
 module.exports = {
   settings: {},
   plugins: [
-    // Signature for adding linting rules (that use unified-lint-rule):
+    // Signature for adding linting rules that use unified-lint-rule:
     //   [require('./rules/rule-name'), [severity, settings]]
-    // Or you can default to 'warn' without including severity
+    // For non-unified-lint-rule rules (or to default to 'warn'), omit serverity:
     //   [require('./rules/rule-name'), settings]
+    // For rules that don't need settings of any kind:
+    //   [require('./rules/rule-name')]
+    [require("./rules/file-require-recipe")],
     [require("./rules/html-require-macros"), ["error", requiredMacros]],
     [require("./rules/html-warn-macros"), allowedMacros]
   ]

--- a/scripts/scraper-ng/rate-limiter.js
+++ b/scripts/scraper-ng/rate-limiter.js
@@ -1,0 +1,3 @@
+const { RateLimit } = require("async-sema");
+
+module.exports = RateLimit(4, { uniformDistribution: true });

--- a/scripts/scraper-ng/rules/file-require-recipe.js
+++ b/scripts/scraper-ng/rules/file-require-recipe.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Check for one and only one valid recipe per file.
+ *
+ */
+function requireRecipe() {
+  return function attacher(tree, file) {
+    if (file.data.recipePath === undefined) {
+      msg(
+        file,
+        "Missing recipe",
+        "file-require-recipe",
+        `Tags: ${JSON.stringify(file.data.tags)}`
+      );
+      return;
+    }
+
+    if (Array.isArray(file.data.recipePath)) {
+      msg(
+        file,
+        `One and only one recipe must apply`,
+        "file-require-recipe-unique",
+        `Recipes: ${JSON.stringify(
+          file.data.recipePath.map(f => path.basename(f, ".yaml"))
+        )}\nTags: ${JSON.stringify(file.data.tags)}`
+      );
+      return;
+    }
+
+    if (!fs.existsSync(file.data.recipePath)) {
+      msg(
+        file,
+        `${file.data.recipePath} does not exist`,
+        "file-require-recipe-file-exists",
+        `Tags: ${JSON.stringify(file.data.tags)}`
+      );
+    }
+  };
+}
+
+function msg(file, text, ruleId, note) {
+  const message = file.message(text);
+  message.fatal = true;
+  message.ruleId = ruleId;
+  message.note = note;
+  return message;
+}
+
+module.exports = requireRecipe;


### PR DESCRIPTION
This is an initial exploration of matching tags for each page to a stumptown recipe, for https://github.com/mdn/sprints/issues/2671.

In the interest of keeping PRs small, I'm opening this PR now even though you can't really judge yet how effective this is for the recipe types specifically. I'm hoping to get feedback on whether this is a good approach to structuring recipe identification; I don't expect this to be the final word on how specific recipe types are matched. 

An important follow up to this PR is going to be a report, with many pages showing how the script matches recipes to pages, and what a manual match would do. I think that data will give us helpful information about what steps we need to take on the wiki and in this code base.

This PR does two big things:

* adds a `kuma-metadata` plugin that fetches `$json` data for pages and attaches some it to the vfile
* adds an `annotate-recipe` that uses the tags list from `kuma-metadata`.

With my earlier caveats in mind, I'm open to any feedback. Some questions I've already asked myself, without good answers yet:

* `kuma-metadata`: Is it a bad name or a terrible name?
* `kuma-metadata`: Should I just attach _all_ the data from `$json` to the vfile?
* `annotate-recipe` warns about missing recipes. Should this be its own check in `/scripts/scraper-ng/rules/` (e.g,. attempt to identify a recipe is one module, but _requiring_ a recipe happens elsewhere)? If not, does this imply that `rules` and `plugins` should just be lumped together?
* `annotate-recipe` goes with the first recipe that matches, mostly because it was easy to write. Should recipe matches be required to be unique (i.e., a page should match one and only recipe?) or should we just concern ourselves with a best effort, by ranking recipe matchers by specificity?

I'm going to flag @wbamberg for review, but tagging @Elchi3 as an FYI. Thanks for taking a look!