### PR TITLE
Add scraper message filtering

### DIFF
--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -84,7 +84,7 @@ async function run() {
 
   const filtered = filterMessages(processed, {
     level: argv.level,
-    ignore: argv.ignore.split(",")
+    ignore: argv.ignore !== "" ? argv.ignore.split(",") : []
   });
 
   console.log(

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -31,6 +31,14 @@ function reporter(files) {
 function summarize(files) {
   const count = countRules(files);
 
+  if (Object.entries(count).length === 0) {
+    return [
+      "",
+      chalk.yellow(chalk.underline("Summary")),
+      "No issues found."
+    ].join("\n");
+  }
+
   const sortedRules = Object.entries(count)
     .map(([ruleId, details]) => ({
       ruleId,


### PR DESCRIPTION
In the course of writing #288, I found it helpful to be able to filter linting messages by level and type. I'm opening this PR to see if it would make sense to make a formal part of the tooling.

(My alternative to this is a `--json` output option that you could pipe into other tools. I won't be heartbroken if one of my proposals is rejected.)