### PR TITLE
Bump js-yaml from 3.12.0 to 3.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,9 +2005,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"


### PR DESCRIPTION
This PR fixes a moderate and high security audit by bumping `js-yaml` to the latest version in `package-lock.json`.  Oddly enough, `dependabot` isn't catching this.