### PR TITLE
Update mapping from tags to recipes

### DIFF
--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -2,6 +2,12 @@ const path = require("path");
 
 const signatures = [
   {
+    recipePath: recipe("javascript-namespace"),
+    conditions: {
+      tags: ["JavaScript", "Namespace"]
+    }
+  },
+  {
     recipePath: recipe("javascript-class"),
     conditions: {
       tags: ["JavaScript", "Class"]
@@ -16,7 +22,7 @@ const signatures = [
   {
     recipePath: recipe("javascript-error"),
     conditions: {
-      tags: ["JavaScript", "Errors"]
+      tags: ["JavaScript", "Error"]
     }
   },
   {
@@ -29,6 +35,24 @@ const signatures = [
     recipePath: recipe("javascript-property"),
     conditions: {
       tags: ["JavaScript", "Property"]
+    }
+  },
+  {
+    recipePath: recipe("javascript-language-feature"),
+    conditions: {
+      tags: ["JavaScript", "Language feature"]
+    }
+  },
+  {
+    recipePath: recipe("landing-page"),
+    conditions: {
+      tags: ["Landing page"]
+    }
+  },
+  {
+    recipePath: recipe("guide"),
+    conditions: {
+      tags: ["Guide"]
     }
   }
 ];


### PR DESCRIPTION
This PR updates the code used by the scraper to map from tags to recipes.

I've added mappings to "javascript-namespace", "javascript-language-feature", "landing-page", and "guide". I also changed the tag we want for error pages from "Errors" to "Error", to be consistent with the others.

A couple of points:
* instead of expecting the "Language feature" tag we could expect things like "Operator" or "Expression" and so on. This would probably result in us having to add fewer tags, but it seemed simpler to have a single new tag for this recipe, than to try to figure out exactly which tags should map to this recipe.
* "Landing page" and "Guide" are weird because they are not specific to JS. This means that eventually, we would need some way for the scraper to know that these are *JavaScript* guide pages, only so it can set the JS sidebar for them. For now at least I think it would be OK for the scraper to do this hardcoded based on the top-level path element.