### PR TITLE
ignore more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Local node installation
 node_modules/
 packaged
+npm-debug.log


### PR DESCRIPTION
Every time something goes wrong with `npm run ...` I get this file that I have to ignore. 
I could put it into my personal `.git/info/exclude` or `~/.gitignore_global` but I think it benefits all users if this is ignored by default for everyone. 