### PR TITLE
Report clickable wiki urls

### DIFF
--- a/scripts/scraper-ng/mdn-url.js
+++ b/scripts/scraper-ng/mdn-url.js
@@ -1,16 +1,16 @@
 /**
- * Return an absolute URL based on `https://developer.mozilla.org`. If the input
- * string is an absolute reference (such as
+ * Return an absolute URL based on `https://wiki.developer.mozilla.org`.
+ * If the input string is an absolute reference (such as
  * `/en-US/docs/Web/HTML/Element/input`), then return an absolute URL (such as
- * `https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input`). If the
- * input string is already an absolute URL, then return that (whether it's an
- * MDN URL or not.)
+ * `https://wiki.developer.mozilla.org/en-US/docs/Web/HTML/Element/input`).
+ * If the input string is already an absolute URL, then return that
+ * (whether it's an MDN URL or not.)
  *
  * @param {String} input
  * @returns {URL} an absolute URL
  */
 function mdnUrl(input) {
-  return new URL(input, "https://developer.mozilla.org/");
+  return new URL(input, "https://wiki.developer.mozilla.org/");
 }
 
 module.exports = mdnUrl;

--- a/scripts/scraper-ng/url-to-vfile.js
+++ b/scripts/scraper-ng/url-to-vfile.js
@@ -20,7 +20,7 @@ async function toVFile(input) {
   const url = mdnUrl(input);
 
   const f = vfile({
-    path: url.pathname,
+    path: url,
     cwd: null,
     data: { url }
   });


### PR DESCRIPTION
I'm using the linter's report to fix some wiki pages. A convenience thing in VS Code is that you can click URLs. Right now the linter reports MDN wiki paths but not full URLs, so this is a proposal to make the report show full clickable URLs allowing me to fix wiki pages faster.

Example output:

```
https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_expression_closures
      1:1  error    Missing recipe                            file-require-recipe
      1:1  error    Compat macro call required but not found  html-require-macros
      1:6  warning  Macro: jsSidebar                          html-warn-on-macros:jssidebar
   14:241  warning  Macro: bug                                html-warn-on-macros:bug
   14:292  warning  Macro: jsxref                             html-warn-on-macros:jsxref
```

The first line is now clickable for me.