### PR TITLE
Increase the rate for scraping wiki pages

### DIFF
--- a/scripts/scraper-ng/rate-limiter.js
+++ b/scripts/scraper-ng/rate-limiter.js
@@ -1,3 +1,3 @@
 const { RateLimit } = require("async-sema");
 
-module.exports = RateLimit(4, { uniformDistribution: true });
+module.exports = RateLimit(16, { uniformDistribution: true });


### PR DESCRIPTION
I've been running the linter at a faster rate over the last week and I haven't had any trouble with it.

This PR was inspired by @Elchi3's quality-of-life improving #321 PR. I figure we should do anything easy that makes the linter more pleasant, so we'll be more likely to use it.