### PR TITLE
Fix bug a bug when printing a summary with no errors

### DIFF
--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -35,7 +35,7 @@ function summarize(files) {
     return [
       "",
       chalk.yellow(chalk.underline("Summary")),
-      "No issues found."
+      "No issues found. Hooray! 🎉"
     ].join("\n");
   }
 

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -31,6 +31,14 @@ function reporter(files) {
 function summarize(files) {
   const count = countRules(files);
 
+  if (Object.entries(count).length === 0) {
+    return [
+      "",
+      chalk.yellow(chalk.underline("Summary")),
+      "No issues found."
+    ].join("\n");
+  }
+
   const sortedRules = Object.entries(count)
     .map(([ruleId, details]) => ({
       ruleId,


### PR DESCRIPTION
If you a lint a page that doesn't have any errors and request for the summary, then you get an exception and unhelpful output. This is sad and disappointing. This PR fixes the exception and prints a cheerful message instead.