### PR TITLE
Add JSON reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3559,6 +3559,11 @@
         }
       }
     },
+    "vfile-reporter-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-reporter-json/-/vfile-reporter-json-2.0.1.tgz",
+      "integrity": "sha512-4bSoKA6DWear1HIaX0JpQrSHTrsESdYsIVmYkG18pqTcCdWZtwzCOj0pkWFLMi+toUSNK1Af1MmKFA9mV1tCSQ=="
+    },
     "vfile-sort": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,11 +424,6 @@
         }
       }
     },
-    "co": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3010,11 +3005,6 @@
         }
       }
     },
-    "sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3311,14 +3301,6 @@
         "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
-      }
-    },
-    "unified-lint-rule": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.4.tgz",
-      "integrity": "sha512-q9wY6S+d38xRAuWQVOMjBQYi7zGyKkY23ciNafB8JFVmDroyKjtytXHCg94JnhBCXrNqpfojo3+8D+gmF4zxJQ==",
-      "requires": {
-        "wrapped": "^1.0.1"
       }
     },
     "unique-concat": {
@@ -3717,15 +3699,6 @@
             "ansi-regex": "^5.0.0"
           }
         }
-      }
-    },
-    "wrapped": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wrapped/-/wrapped-1.0.1.tgz",
-      "integrity": "sha1-x4PZ2Aeyc+mwHoUWgKk4yHyQckI=",
-      "requires": {
-        "co": "3.1.0",
-        "sliced": "^1.0.1"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "unist-util-visit": "^2.0.2",
         "vfile": "^4.0.3",
         "vfile-reporter": "^6.0.1",
+        "vfile-reporter-json": "^2.0.1",
         "vfile-statistics": "^1.1.4"
     },
     "remarkConfig": {

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
         "retext-stringify": "^2.0.4",
         "to-vfile": "^6.0.1",
         "unified": "^8.4.2",
-        "unified-lint-rule": "^1.0.4",
         "unist-util-filter": "^2.0.2",
         "unist-util-visit": "^2.0.2",
         "vfile": "^4.0.3",
+        "vfile-message": "^2.0.3",
         "vfile-reporter": "^6.0.1",
         "vfile-reporter-json": "^2.0.1",
         "vfile-statistics": "^1.1.4"

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -1,5 +1,7 @@
 const fetch = require("node-fetch");
 const fileReporter = require("vfile-reporter");
+const jsonReporter = require("vfile-reporter-json");
+const VMessage = require("vfile-message");
 const yargs = require("yargs");
 
 const kumascriptRehype = require("./plugins/kumascript-rehype-parse");
@@ -7,9 +9,6 @@ const limiter = require("./rate-limiter");
 const mdnUrl = require("./mdn-url");
 const summaryReporter = require("./vfile-reporter-summary");
 const toVFile = require("./url-to-vfile");
-const VMessage = require("vfile-message");
-
-const jsonReporter = require("vfile-reporter-json");
 
 const examplePage =
   "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div";

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -9,6 +9,8 @@ const summaryReporter = require("./vfile-reporter-summary");
 const toVFile = require("./url-to-vfile");
 const VMessage = require("vfile-message");
 
+const jsonReporter = require("vfile-reporter-json");
+
 const examplePage =
   "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div";
 const exampleShorthand = "/en-US/docs/Web/HTML/Element/div";
@@ -18,6 +20,9 @@ const { argv } = yargs
   .usage("Usage: $0 <url>")
   .example(`$0 ${examplePage}`, "scrape a page and all its subpages")
   .example(`$0 ${exampleShorthand}`, "omit the protocol and domain")
+
+  .describe("json", "Format results as JSON")
+  .example(`$0 --json ${exampleShorthand}`)
 
   .describe("n", "Dry run (lint-only)")
   .alias("n", "dry-run")
@@ -82,9 +87,10 @@ async function run() {
 
   console.log(
     report(processed, {
+      json: argv.json,
       quiet: argv.quiet,
-      verbose: argv.verbose,
-      summary: argv.summary
+      summary: argv.summary,
+      verbose: argv.verbose
     })
   );
 }
@@ -116,13 +122,16 @@ function flattenTree(root) {
  * @param {Array.<VFile>} files - processed files to report on
  * @param {Object} [options={}] - options for report formats. Options are also
  * passed through to the end reporter; see specific reporters for additional options.
- * @param {boolean} [options.summary=false] - append a summary
+ * @param {boolean} [options.json=false] - format the report as JSON
+ * @param {boolean} [options.summary=false] - append a summary (not applicable to JSON reports)
  * @returns {String} - a report string
  */
 function report(files, options = {}) {
   let reporter = fileReporter;
 
-  if (options.summary) {
+  if (options.json) {
+    reporter = jsonReporter;
+  } else if (options.summary) {
     reporter = summaryReporter;
   }
 

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -62,12 +62,12 @@ async function run() {
   const root = await fetchTree(argv._[0]);
   const urls = argv.noSubpages ? [root.url] : flattenTree(root);
 
-  console.log(`Preparing to lint ${urls.length} pages…`);
+  console.error(`Preparing to lint ${urls.length} pages…`);
   await new Promise(resolve => setTimeout(resolve, 2000)); // give 2 seconds to gracefully bail out
 
   const files = urls.map(async url => {
     await limiter();
-    if (!argv.quiet) console.log(`Fetching ${url}`);
+    if (!argv.quiet) console.error(`Fetching ${url}`);
     const file = await toVFile(url);
     const hasFileErrors = file.messages.length > 0;
     if (!hasFileErrors) {

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -116,7 +116,7 @@ function flattenTree(root) {
  * @param {Array.<VFile>} files - processed files to report on
  * @param {Object} [options={}] - options for report formats. Options are also
  * passed through to the end reporter; see specific reporters for additional options.
- * @param {boolean} [options.summary=false] - print a summary report
+ * @param {boolean} [options.summary=false] - append a summary
  * @returns {String} - a report string
  */
 function report(files, options = {}) {

--- a/scripts/scraper-ng/index.js
+++ b/scripts/scraper-ng/index.js
@@ -81,14 +81,12 @@ async function run() {
   const processed = await Promise.all(files);
 
   console.log(
-    fileReporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
+    report(processed, {
+      quiet: argv.quiet,
+      verbose: argv.verbose,
+      summary: argv.summary
+    })
   );
-
-  if (argv.summary) {
-    console.log(
-      summaryReporter(processed, { quiet: argv.quiet, verbose: argv.verbose })
-    );
-  }
 }
 
 async function fetchTree(input) {
@@ -110,6 +108,25 @@ function flattenTree(root) {
   }
 
   return urls;
+}
+
+/**
+ * Choose and generate a report.
+ *
+ * @param {Array.<VFile>} files - processed files to report on
+ * @param {Object} [options={}] - options for report formats. Options are also
+ * passed through to the end reporter; see specific reporters for additional options.
+ * @param {boolean} [options.summary=false] - print a summary report
+ * @returns {String} - a report string
+ */
+function report(files, options = {}) {
+  let reporter = fileReporter;
+
+  if (options.summary) {
+    reporter = summaryReporter;
+  }
+
+  return reporter(files, options);
 }
 
 run();

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -125,7 +125,7 @@ function formatRule({ count, fatal, reason, ruleId }) {
 function formatStats(files, summaryLines) {
   const { fatal, nonfatal, total } = statistics(files);
 
-  const notices = total > 0 ? `${total} notice${plural(total)}` : "";
+  const notices = total > 0 ? `${total} message${plural(total)}` : "";
   const errors =
     fatal > 0 ? `${chalk.red("✖")} ${fatal} error${plural(fatal)}` : "";
   const warnings =
@@ -137,7 +137,7 @@ function formatStats(files, summaryLines) {
   const parenthetical = breakdown ? `(${breakdown})` : "";
 
   return [
-    `${summaryLines.length} notice type${plural(summaryLines.length)}`,
+    `${summaryLines.length} message type${plural(summaryLines.length)}`,
     parenthetical,
     `in ${files.length} file${plural(files.length)}`
   ].join(" ");

--- a/scripts/scraper-ng/vfile-reporter-summary.js
+++ b/scripts/scraper-ng/vfile-reporter-summary.js
@@ -1,13 +1,22 @@
 const chalk = require("chalk");
+const fileReporter = require("vfile-reporter");
 const statistics = require("vfile-statistics");
 
 /**
- * Generate a summary report of VFile messages.
+ * Create a report for one or more vfiles and add a summary.
  *
- * @param {(VFile|Array.<VFile>|Error)} files - `VFile`, `Array.<VFile>`, or `Error`
- * @returns {String} the summary as a string
+ * @param {(VFile|Array.<VFile>|Error)} files - `VFile`, `Array.<VFile>`, or
+ * `Error`
+ * @param {Object} options - settings for `vfile-reporter`
+ * @param {boolean} [options.verbose=false] - Output long form descriptions of
+ * messages
+ * @param {boolean} [options.quiet=false] - Do not output anything for a file
+ * which has no warnings or errors
+ * @param {boolean} [options.silent=false] - Do not output messages without
+ * `fatal` set to `true`. Also sets `quiet` to `true`.
+ * @returns {String} the report as a string
  */
-function reporter(files) {
+function reporter(files, options) {
   // Undefined or `null`
   if (!files) {
     return "";
@@ -24,8 +33,8 @@ function reporter(files) {
     files = [files];
   }
 
-  // Actually generate the summary
-  return summarize(files);
+  // Actually generate the report
+  return [fileReporter(files, options), summarize(files)].join("\n");
 }
 
 function summarize(files) {


### PR DESCRIPTION
This adds an initial JSON reporter. There were a few fiddly things I had to fix to get there, but that's the gist of the changes here.

Now you can do some fun things, like abuse `jq` to generate CSV for pages and their number of errors:

```shell
node ./scripts/scraper-ng /en-US/docs/Web/JavaScript/Reference/Global_Objects/Array --json | \
jq --raw-output '.[] | [.path, (.messages | length)] | @csv'
```

or to get a list of pages with ingredient problems:

```shell
node ./scripts/scraper-ng /en-US/docs/Web/JavaScript/Reference/Global_Objects/Array --json | \
jq --raw-output '.[] .messages |= [.[] | select(.source | tostring | contains("ingredient"))] | .[] | select(.messages | length > 0) | .path'
```

Fixes #336.