### PR TITLE
Rename and revise linter rules and messages

### DIFF
--- a/scripts/scraper-ng/preset.js
+++ b/scripts/scraper-ng/preset.js
@@ -10,7 +10,7 @@ module.exports = {
     // For rules that don't need settings of any kind:
     //   [require('./rules/rule-name')]
     [require("./rules/file-require-recipe")],
-    [require("./rules/html-warn-macros"), allowedMacros],
+    [require("./rules/html-no-macros"), allowedMacros],
     [require("./rules/html-require-recipe-ingredients")]
   ]
 };

--- a/scripts/scraper-ng/rules/file-require-recipe.js
+++ b/scripts/scraper-ng/rules/file-require-recipe.js
@@ -12,7 +12,7 @@ function requireRecipe() {
     if (file.data.recipePath === undefined) {
       msg(
         file,
-        "Missing recipe",
+        "Recipe is missing",
         "recipe-missing",
         `Tags: ${JSON.stringify(file.data.tags)}`
       );
@@ -22,7 +22,7 @@ function requireRecipe() {
     if (Array.isArray(file.data.recipePath)) {
       msg(
         file,
-        `One and only one recipe must apply`,
+        `Recipe is not unique`,
         "recipe-not-unique",
         `Recipes: ${JSON.stringify(
           file.data.recipePath.map(f => path.basename(f, ".yaml"))
@@ -34,7 +34,10 @@ function requireRecipe() {
     if (!fs.existsSync(file.data.recipePath)) {
       msg(
         file,
-        `${path.relative(process.cwd(), file.data.recipePath)} does not exist`,
+        `Recipe file (${path.relative(
+          process.cwd(),
+          file.data.recipePath
+        )}) does not exist`,
         "recipe-file-missing",
         `Tags: ${JSON.stringify(file.data.tags)}`
       );

--- a/scripts/scraper-ng/rules/file-require-recipe.js
+++ b/scripts/scraper-ng/rules/file-require-recipe.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const path = require("path");
 
+const source = "file-require-recipe";
+
 /**
  * Check for one and only one valid recipe per file.
  *
@@ -11,7 +13,7 @@ function requireRecipe() {
       msg(
         file,
         "Missing recipe",
-        "file-require-recipe",
+        "recipe-missing",
         `Tags: ${JSON.stringify(file.data.tags)}`
       );
       return;
@@ -21,7 +23,7 @@ function requireRecipe() {
       msg(
         file,
         `One and only one recipe must apply`,
-        "file-require-recipe-unique",
+        "recipe-not-unique",
         `Recipes: ${JSON.stringify(
           file.data.recipePath.map(f => path.basename(f, ".yaml"))
         )}\nTags: ${JSON.stringify(file.data.tags)}`
@@ -32,18 +34,17 @@ function requireRecipe() {
     if (!fs.existsSync(file.data.recipePath)) {
       msg(
         file,
-        `${file.data.recipePath} does not exist`,
-        "file-require-recipe-file-exists",
+        `${path.relative(process.cwd(), file.data.recipePath)} does not exist`,
+        "recipe-file-missing",
         `Tags: ${JSON.stringify(file.data.tags)}`
       );
     }
   };
 }
 
-function msg(file, text, ruleId, note) {
-  const message = file.message(text);
+function msg(file, text, rule, note) {
+  const message = file.message(text, `${source}:${rule}`);
   message.fatal = true;
-  message.ruleId = ruleId;
   message.note = note;
   throw message;
 }

--- a/scripts/scraper-ng/rules/html-no-macros.js
+++ b/scripts/scraper-ng/rules/html-no-macros.js
@@ -2,7 +2,7 @@ const visit = require("unist-util-visit");
 
 const normalizeMacroName = require("../normalize-macro-name");
 
-const source = "html-warn-macros";
+const source = "html-no-macros";
 
 /**
  * Issue a warning for each macro call (except for the array of macro names in

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers.js
@@ -5,7 +5,7 @@ const visit = require("unist-util-visit");
 
 const normalizeMacroName = require("../../normalize-macro-name");
 
-const ruleNamespace = "html-require-ingredient";
+const source = "html-require-ingredient";
 
 /**
  * Functions to check for recipe ingredients in Kuma page sources.
@@ -27,7 +27,7 @@ const ingredientHandlers = {
   default: (tree, file, context) => {
     const { recipeName, ingredient } = context;
     const rule = `${recipeName}/${ingredient}`;
-    const origin = `${ruleNamespace}:${rule}`;
+    const origin = `${source}:${rule}`;
 
     file.message(`Linting ${ingredient} ingredient is unimplemented`, origin);
   },
@@ -40,7 +40,7 @@ const ingredientHandlers = {
       const message = file.message(
         `Expected h2#${id}`,
         body,
-        `${ruleNamespace}:${context.recipeName}/${context.ingredient}/expected-heading`
+        `${source}:${context.recipeName}/${context.ingredient}/expected-heading`
       );
       message.fatal = true;
       logMissingIngredient(file, context);
@@ -70,7 +70,7 @@ const ingredientHandlers = {
       const message = file.message(
         `Expected h2#${id}`,
         body,
-        `${ruleNamespace}:${context.recipeName}/${context.ingredient}/expected-heading`
+        `${source}:${context.recipeName}/${context.ingredient}/expected-heading`
       );
       message.fatal = true;
       logMissingIngredient(file, context);
@@ -94,7 +94,7 @@ const ingredientHandlers = {
       const message = file.message(
         `Expected SpecName macro for ${context.recipeName}: ${context.ingredient}`,
         heading,
-        `${ruleNamespace}:${context.recipeName}/${context.ingredient}/expected-macro`
+        `${source}:${context.recipeName}/${context.ingredient}/expected-macro`
       );
       message.fatal = true;
       logMissingIngredient(file, context);
@@ -270,7 +270,7 @@ function isMacro(node, macroName) {
 function logMissingIngredient(file, context) {
   const { recipeName, ingredient } = context;
   const rule = `${recipeName}/${ingredient}`;
-  const origin = `${ruleNamespace}:${rule}`;
+  const origin = `${source}:${rule}`;
 
   const message = file.message(
     `Missing from ${recipeName}: ${ingredient}`,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers.js
@@ -38,7 +38,7 @@ const ingredientHandlers = {
 
     if (heading === null) {
       const message = file.message(
-        `Expected h2#${id} for ${context.recipeName}: ${context.ingredient}`,
+        `Expected h2#${id}`,
         body,
         `${ruleNamespace}:${context.recipeName}/${context.ingredient}/expected-heading`
       );
@@ -68,7 +68,7 @@ const ingredientHandlers = {
     const heading = select(`h2#${id}`, body);
     if (heading === null) {
       const message = file.message(
-        `Expected h2#${id} ${context.recipeName}: ${context.ingredient}`,
+        `Expected h2#${id}`,
         body,
         `${ruleNamespace}:${context.recipeName}/${context.ingredient}/expected-heading`
       );

--- a/scripts/scraper-ng/rules/html-warn-macros.js
+++ b/scripts/scraper-ng/rules/html-warn-macros.js
@@ -2,6 +2,8 @@ const visit = require("unist-util-visit");
 
 const normalizeMacroName = require("../normalize-macro-name");
 
+const source = "html-warn-macros";
+
 /**
  * Issue a warning for each macro call (except for the array of macro names in
  * `allowedMacros`)
@@ -20,8 +22,11 @@ function attacher(allowedMacros) {
         node.data.macroName &&
         !allowedMacros.includes(node.data.macroName),
       node => {
-        const message = file.message(`Macro: ${node.data.macroCall}`, node);
-        message.ruleId = `html-warn-on-macros:${node.data.macroName}`;
+        const message = file.message(
+          `Macro: ${node.data.macroCall}`,
+          node,
+          `${source}:${node.data.macroName}`
+        );
         message.note = `With arguments: ${JSON.stringify(
           node.data.macroParams
         )}`;


### PR DESCRIPTION
This PR tries to clean up the linting messages by condensing some of the messages (to avoid hitting the max width of your terminal) and using a more consistent scheme for rule origins and IDs. This PR fixes #331.

In more detail, here's what I've tried to do with this PR:

* All rules get a namespace (`vfile-message` uses the word "source" for this, which may be a bit confusing, but I've tried to be consistent about this). Each namespace is named for the plugin that emits the message (e.g., `file-require-recipe` is the name of a plugin and, now, a namespace for rule IDs).
* Where practical, rule messages start with the same word or phrase within the same name space (e.g., all the recipe messages start with "Recipe").
* Messages were adjusted for length to try fit into narrower terminals.
* `html-warn-macros` has been renamed to `html-no-macros` to get the spirit of the rule and to remove the message level from the name of the module and namespace.

If you're using the JSON output, you can now filter against the name `ruleId` or `source`, to filter the rule or namespace, respectively:

```
"ruleId": "jsxref",
"source": "html-no-macros"
```

None of them should be `null` now.