### PR TITLE
Make JS description sections optional

### DIFF
--- a/content/en-US/css/reference/properties/transform/transform.md
+++ b/content/en-US/css/reference/properties/transform/transform.md
@@ -16,7 +16,7 @@ examples:
 The **`transform`** [CSS](/en-US/docs/Web/CSS) property lets you rotate,
 scale, skew, or translate an element.
 
-## Overview
+## Description
 
 This property modifies the coordinate space
 of the CSS [visual formatting

--- a/content/en-US/html/HTML.md
+++ b/content/en-US/html/HTML.md
@@ -13,7 +13,7 @@ link_lists:
       - "/content/en-US/html/reference/elements"
 ---
 
-## Overview
+## Description
 
 **HTML** (HyperText Markup Language) is the most basic building block of the Web. It defines the meaning and structure of web content. Other technologies besides HTML are generally used to describe a web page's appearance/presentation ([CSS](/en-US/docs/Web/CSS)) or functionality/behavior ([JavaScript](/en-US/docs/Web/JavaScript)).
 

--- a/content/en-US/html/reference/elements/article/article.md
+++ b/content/en-US/html/reference/elements/article/article.md
@@ -32,7 +32,7 @@ in a document, page, application, or site, which is intended to be
 independently distributable or reusable (e.g., in syndication). Examples
 include: a forum post, a magazine or newspaper article, or a blog entry.
 
-## Overview
+## Description
 
 A given document can have multiple articles in it; for example, on a
 blog that shows the text of each article one after another as the reader

--- a/content/en-US/html/reference/elements/body/body.md
+++ b/content/en-US/html/reference/elements/body/body.md
@@ -21,7 +21,7 @@ recipe: html-element
 The **HTML `<body>` Element** represents the content of an HTML
 document.
 
-## Overview
+## Description
 
 There can be only one `<body>` element in a document.
 

--- a/content/en-US/html/reference/elements/elements.md
+++ b/content/en-US/html/reference/elements/elements.md
@@ -8,6 +8,6 @@ link_lists:
     directory: "/content/en-US/html/reference/elements"
 ---
 
-## Overview
+## Description
 
 This page lists all the HTML elements, which are created using tags...

--- a/content/en-US/html/reference/elements/input-button/input-button.md
+++ b/content/en-US/html/reference/elements/input-button/input-button.md
@@ -26,7 +26,7 @@ recipe: html-input-element
 
 [`<input>`](/en-US/docs/Web/HTML/Element/input) elements of type **`button`** are rendered as simple push buttons, which can be programmed to control custom functionality anywhere on a webpage as required when assigned an event handler function (typically for the `click` event).
 
-## Overview
+## Description
 
 While `<input>` elements of type `button` are still perfectly valid HTML, the newer [`<button>`](/en-US/docs/Web/HTML/Element/button) element is now the favored way to create buttons. Given that a [`<button>`](/en-US/docs/Web/HTML/Element/button)’s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
 

--- a/content/en-US/html/reference/elements/input/input.md
+++ b/content/en-US/html/reference/elements/input/input.md
@@ -28,7 +28,7 @@ recipe: html-element
 
 The **HTML `<input>` element** is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and [user agent](/en-US/docs/Glossary/user_agent).
 
-## Overview
+## Description
 
 How an `<input>` works varies considerably depending on the value of its `type` attribute, hence the different types are covered in their own separate reference pages. If this attribute is not specified, the default type adopted is `text`.
 

--- a/content/en-US/html/reference/elements/video/video.md
+++ b/content/en-US/html/reference/elements/video/video.md
@@ -26,7 +26,7 @@ recipe: html-element
 The **HTML Video element** (**`<video>`**) embeds a media player which
 supports video playback into the document.
 
-## Overview
+## Description
 
 You can use `<video>` for audio content as well, but the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
 element may provide a more appropriate user experience.

--- a/project-docs/html-element.md
+++ b/project-docs/html-element.md
@@ -7,7 +7,7 @@ The overall outline of an HTML element reference page on MDN is like this:
 ```
 short description prose
 interactive example
-overview prose
+description prose
 
 H2 Attributes
 attributes prose
@@ -39,21 +39,21 @@ The recipe for an HTML element, as it's currently specified, is like this:
 
 ```yml
 body:
-- prose.short-description
-- meta.interactive-example?
-- prose.overview?
-- prose.attributes-text?
-- meta.attributes
-- prose.usage-notes
-- prose.*
-- prose.accessibility-concerns?
-- meta.examples
-- meta.info-box:
-    - meta.api
-    - meta.permitted-aria-roles
-    - meta.tag_omission
-- meta.browser-compatibility
-- prose.see-also
+  - prose.short-description
+  - meta.interactive-example?
+  - prose.description?
+  - prose.attributes-text?
+  - meta.attributes
+  - prose.usage-notes
+  - prose.*
+  - prose.accessibility-concerns?
+  - meta.examples
+  - meta.info-box:
+      - meta.api
+      - meta.permitted-aria-roles
+      - meta.tag_omission
+  - meta.browser-compatibility
+  - prose.see-also
 ```
 
 Entries in the recipe are either prefixed "prose.", in which case they are bits of the prose.md file and are generally just inserted as Markdown, or they are prefixed "meta." in which case they are bits of the meta.yaml file. Some meta.yaml entries point somewhere else and require special handling.
@@ -67,7 +67,7 @@ Maybe the "recipe" is more like the first block above, that explicitly represent
 ```yml
 - prose.short-description
 - meta.interactive-example?
-- prose.overview?
+- prose.description?
 - H2.Attributes
 - prose.attributes-text?
 - meta.attributes
@@ -110,7 +110,7 @@ The linked page should be embedded in an iframe for inclusion in the page - in K
 
 The way we handle interactive examples here is likely to change in the future, but that's a different conversation.
 
-### prose.overview
+### prose.description
 
 Optional.
 
@@ -136,23 +136,23 @@ For MDN pages we could just handle "global" with some text like "Like all other 
 
 "element-specific": is more complicated. The directory pointed to should contain one or more Markdown files each of which documents an attribute. Each of those files has its own structure:
 
-* front matter which is currently just a BCD reference
+- front matter which is currently just a BCD reference
 
-* H1: this is the name of the attribute (marked up in ``), and is followed by some freeform Markdown describing the attribute.
+- H1: this is the name of the attribute (marked up in ``), and is followed by some freeform Markdown describing the attribute.
 
-* H2 "Values" (optional): If present this contains the values it can take. Each H3 under here is the value's name (marked up in ``), and is followed by some Markdown describing that value.
+- H2 "Values" (optional): If present this contains the values it can take. Each H3 under here is the value's name (marked up in ``), and is followed by some Markdown describing that value.
 
-* H2: "Type" (mandatory (?)): If present this is followed by a string describing the type of the attribute. I think this ought to be an enumerated list of possible types, including "String", "Boolean", "Number", and possibly "URL".
+- H2: "Type" (mandatory (?)): If present this is followed by a string describing the type of the attribute. I think this ought to be an enumerated list of possible types, including "String", "Boolean", "Number", and possibly "URL".
 
 For an example of a relatively complex attribute see [video.crossorigin](https://github.com/mdn/stumptown-content/blob/master/content/html/elements/video/attributes/crossorigin.md).
 
 To render it in an MDN page, we could say:
 
-* element-specific attributes are a `<dl>`
+- element-specific attributes are a `<dl>`
 
-* each attribute is a `<dt><dd>` item, where the `<dt>` is the attribute name and the `<dd>` is the description.
+- each attribute is a `<dt><dd>` item, where the `<dt>` is the attribute name and the `<dd>` is the description.
 
-* the `<dd>` description starts with the type, followed by the description. If values are specified they are given as a `<ul>`, in which each `<li>` consists of the value name followed by the value description.
+- the `<dd>` description starts with the type, followed by the description. If values are specified they are given as a `<ul>`, in which each `<li>` consists of the value name followed by the value description.
 
 This would give us something close to what MDN currently does to render attributes (see for example "referrerpolicy" in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Attributes ). We might choose to do something different though, and MDN is currently quite inconsistent here.
 
@@ -164,7 +164,7 @@ This is found as a named section of the prose.md file.
 
 It's a blob of Markdown that should just be converted to HTML and added to the document.
 
-### prose.*
+### prose.\*
 
 Optional.
 
@@ -190,30 +190,30 @@ The meta.examples item does not cover interactive-examples, they are handled sep
 
 There are two cases to handle:
 
-* static examples which are really just a code block and a text description
+- static examples which are really just a code block and a text description
 
-* live examples which are a text description plus some executable code, which need to be made executable in the page (for example in an iframe as [the current live samples do](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Code_examples#Traditional_live_samples))
+- live examples which are a text description plus some executable code, which need to be made executable in the page (for example in an iframe as [the current live samples do](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Structures/Code_examples#Traditional_live_samples))
 
 So, "meta.examples" is found as a property in the meta.yaml file. It's a list of paths relative to the meta.yaml file. Each item in the list specifies an example, and examples should be rendered in the order given (this is different from the specification of attributes, which just gives you a directory: that's because writers want to present examples in a particular order, while attributes should always be listed alphabetically).
 
 To render each example, look in its directory. I think we probably need to think more about the specification of an example, but it's something like this.
 
-* an example may have any of the following files:
-    * a file called "description.md"
-    * files called "example.js", "example.css", "example.html"
+- an example may have any of the following files:
+  - a file called "description.md"
+  - files called "example.js", "example.css", "example.html"
 
 If "description.md" exists it may have:
 
-* a front matter section that may contain:
-    * "title": if this is present the example gets an H3 heading containing the specified title text
-    * "width" and "height": if these are present then the example is a live sample, and these properties define the width and height of the output iframe in pixels.
-
+- a front matter section that may contain:
+  - "title": if this is present the example gets an H3 heading containing the specified title text
+  - "width" and "height": if these are present then the example is a live sample, and these properties define the width and height of the output iframe in pixels.
 
 * some Markdown text describing what the example does (or sometimes, just referring the reader to a different page where examples could be found, e.g. in [col#Examples](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#Examples). If this is present it should be rendered as HTML after the H3 heading, if there was one.
 
-For any example.* files found:
-* they are rendered as code blocks (probably with a heading identifying JS/CSS/HTML?) in some predefined order (maybe HTML, CSS, JS?)
-* if the example is to be treated as a live sample, then that has to be handled in a functionally similar way to that in which Kuma handles live samples now (this is I believe a combination of the [EmbedLiveSample macro](https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs) and some Kuma core code). This gives an output box in which the result of the code is shown.
+For any example.\* files found:
+
+- they are rendered as code blocks (probably with a heading identifying JS/CSS/HTML?) in some predefined order (maybe HTML, CSS, JS?)
+- if the example is to be treated as a live sample, then that has to be handled in a functionally similar way to that in which Kuma handles live samples now (this is I believe a combination of the [EmbedLiveSample macro](https://github.com/mdn/kumascript/blob/master/macros/EmbedLiveSample.ejs) and some Kuma core code). This gives an output box in which the result of the code is shown.
 
 As I say, I think we might want to improve the specification of examples. This is a first effort to try to capture the main ways in which people write examples at the moment. I'd like to find a balance between giving writers flexibility to present examples in the way they want, and keeping the code that handles them from being too complicated.
 
@@ -227,11 +227,11 @@ Mandatory.
 
 This is data for the blue box that shows up in all pages, sometimes under the heading ["Technical summary"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Technical_summary). We're not sure yet exactly which data should be in this box, but that the moment we're listing three things:
 
-* meta.api: identifies the JavaScript interface to the element. Although it's just specified as a string at the moment, it should probably be a link.
+- meta.api: identifies the JavaScript interface to the element. Although it's just specified as a string at the moment, it should probably be a link.
 
-* meta.permitted-aria-roles: get this from the meta.yaml file. It lists, well, permitted ARIA roles. I think it is a bit underspecified at the moment.
+- meta.permitted-aria-roles: get this from the meta.yaml file. It lists, well, permitted ARIA roles. I think it is a bit underspecified at the moment.
 
-* meta.tag_omission: whether you can omit the closing tag. Obviously this should be renamed "meta.tag-omission".
+- meta.tag_omission: whether you can omit the closing tag. Obviously this should be renamed "meta.tag-omission".
 
 All these items can be got from the meta.yaml file, and they should be rendered into a table/box like the blue box that's there now.
 

--- a/project-docs/stumptown-status.md
+++ b/project-docs/stumptown-status.md
@@ -4,13 +4,13 @@ This document describes the current state of our attempts to describe a replacem
 
 We're trying to describe a replacement that will meet the following objectives:
 
-* pull request model for content updates: content will live on GitHub and be updated using pull requests
-* a structure for reference docs:
-    * concisely and clearly define and enforce the structure that docs (especially reference docs) will follow
-    * be able to restructure reference docs relatively easily
-    * be able to offer the structured content to third parties via an API
-* make it easy to contribute to our docs using commonly understood tools and formats
-* have a website that's faster, simpler, and easier to maintain than Kuma
+- pull request model for content updates: content will live on GitHub and be updated using pull requests
+- a structure for reference docs:
+  - concisely and clearly define and enforce the structure that docs (especially reference docs) will follow
+  - be able to restructure reference docs relatively easily
+  - be able to offer the structured content to third parties via an API
+- make it easy to contribute to our docs using commonly understood tools and formats
+- have a website that's faster, simpler, and easier to maintain than Kuma
 
 This is not intended to be a clone of Kuma. We will implement what we actually need, not whatever Kuma does. There will be things that were possible in Kuma that will not be possible in the replacement, where we think that these things are not essential and that supporting them will prevent us from meeting the objectives above.
 
@@ -28,13 +28,13 @@ One problem with this "directive-based" approach is that the documents have no s
 
 In the new proposal we want to define "recipes" for different sorts of MDN reference docs - HTML element docs, CSS property docs, and so on. A recipe describes a particular collection of sections arranged in a particular order. For example:
 
-* short description
-* interactive example
-* overview
-* accessibility concerns
-* live examples
-* browser compatibility
-* see also
+- short description
+- interactive example
+- description
+- accessibility concerns
+- live examples
+- browser compatibility
+- see also
 
 We want the code that builds MDN reference documents to use these recipes to build complete documents out of the sections.
 
@@ -54,24 +54,25 @@ The problem of both these approaches is that they tend to make writing more diff
 
 So part of designing a solution is to find a balance where structured content is possible but writers are not too frustrated. In general, it's a goal as far as possible to:
 
-* have a "holistic source document": keep the prose content together in a single piece, that makes sense on its own
-* use a simple format for authoring the prose content.
+- have a "holistic source document": keep the prose content together in a single piece, that makes sense on its own
+- use a simple format for authoring the prose content.
 
 ### Prose format choices
 
 One basic question is: which format should we use for writing prose? There are two main criteria we'd like to satisfy here:
 
-* it should be easy to read and write
-* it should enable authors to express semantic structure in a machine-readable way: for example, it would be useful for us to be able to mark up a section of a doc as the "short description" and have software able to extract this reliably.
+- it should be easy to read and write
+- it should enable authors to express semantic structure in a machine-readable way: for example, it would be useful for us to be able to mark up a section of a doc as the "short description" and have software able to extract this reliably.
 
 Unfortunately these tend to be opposed. At one extreme is something like DITA, which would enable us to express semantics very well, but is too hard for most people to want to write. At the other extreme is Markdown, which is very easy to write but is incapable of expressing semantics: it's purely a presentational language.
 
 Somewhere in between is reStructuredText, which is fairly easy to write but still enables us to express some semantic structure.
 
 Currently it's our recommendation to use Markdown. This has some serious disadvantages:
-* multiple competing versions: we would probably choose GitHub Flavored Markdown.
-* very limited: even basic elements like `<dl>` can't be expressed directly in basic Markdown.
-* most seriously, no ability to express semantics: Markdown is entirely presentational. This will lead us into some hacks later on.
+
+- multiple competing versions: we would probably choose GitHub Flavored Markdown.
+- very limited: even basic elements like `<dl>` can't be expressed directly in basic Markdown.
+- most seriously, no ability to express semantics: Markdown is entirely presentational. This will lead us into some hacks later on.
 
 However Markdown is so ubiquitous and so easy to write that it's hard to imagine anything else being accepted by authors. Everyone already knows Markdown: choosing anything else is asking a large proportion of people to learn a new format just for MDN. reStructuredText seems promising but it seems as if even people who already know it don't like using it.
 
@@ -97,8 +98,8 @@ content
 
 In directories that want a page in MDN (for example, `transform` and `video` in the example above) we will have at least two files:
 
-* `meta.yaml`
-* `prose.md`
+- `meta.yaml`
+- `prose.md`
 
 The `prose.md` file contains the prose content part of the page. It's written in GitHub Flavored Markdown. The `meta.yaml` file contains supplementary information needed to build the complete page.
 
@@ -112,40 +113,40 @@ This will match the name of a YAML file in the `recipes` directory. Here's what 
 
 ```yaml
 body:
-- prose.short-description
-- meta.interactive-example
-- prose.overview
-- meta.attributes
-- prose.usage-notes
-- prose.*
-- prose.accessibility-concerns?
-- meta.examples
-- meta.info-box:
-    - meta.api
-    - meta.permitted-aria-roles
-    - meta.tag_omission
-- meta.specifications
-- meta.browser-compatibility
-- prose.see-also
+  - prose.short-description
+  - meta.interactive-example
+  - prose.description?
+  - meta.attributes
+  - prose.usage-notes
+  - prose.*
+  - prose.accessibility-concerns?
+  - meta.examples
+  - meta.info-box:
+      - meta.api
+      - meta.permitted-aria-roles
+      - meta.tag_omission
+  - meta.specifications
+  - meta.browser-compatibility
+  - prose.see-also
 ```
 
 Each property in this file represents a section of the document, listed in the order that they should appear. Some properties are prefixed `prose.`: this means that their content should be extracted from the `prose.md` file for the item. Other properties are prefixed `meta.`: this means that their content needs to be constructed using some custom process based on parameters that can be found in the `meta.yaml` file for the item.
 
 So the way the page builder will proceed is:
 
-* open the item's `meta.yaml` and get the value of its `recipe` property
-* use this to find the recipe for this item
-* use the other properties of `meta.yaml`, and the contents of `prose.md`, to construct the complete document.
+- open the item's `meta.yaml` and get the value of its `recipe` property
+- use this to find the recipe for this item
+- use the other properties of `meta.yaml`, and the contents of `prose.md`, to construct the complete document.
 
 For example:
 
-* the page builder opens `content/html/elements/video`
-* it opens `meta.yaml` and finds `html-element` as the value of `recipe`
-* it finds `html-element.yaml` in `recipes`:
-    * it extracts the `short-description` section from `video/prose.md`
-    * it fetches the URL for the interactive example from the `interactive-examples` property in `video/meta.yaml`
-    * it extracts the `overview` section from `video/prose.md`
-    * ...and so on.
+- the page builder opens `content/html/elements/video`
+- it opens `meta.yaml` and finds `html-element` as the value of `recipe`
+- it finds `html-element.yaml` in `recipes`:
+  - it extracts the `short-description` section from `video/prose.md`
+  - it fetches the URL for the interactive example from the `interactive-examples` property in `video/meta.yaml`
+  - it extracts the `description` section from `video/prose.md`
+  - ...and so on.
 
 The idea is that recipes provide a concise description of the structure of the various MDN page types, that is kept in one place and is enforced by the code that constructs MDN pages.
 
@@ -155,34 +156,34 @@ Here's what the `meta.yaml` file for `video` might look like:
 
 ```yaml
 recipe: html-element
-title: '<video>: The Video Embed element'
+title: "<video>: The Video Embed element"
 mdn-url: https://developer.mozilla.org/docs/Web/HTML/Element/video
 tags:
-    group: Image and multimedia
+  group: Image and multimedia
 dom-interface: HTMLVideoElement
 permitted-aria-roles: application
 tag_omission: none
 interactive-example: https://interactive-examples.mdn.mozilla.net/pages/tabbed/video.html
 specifications:
-    - link: https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element
-      status: Living Standard
+  - link: https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element
+    status: Living Standard
 browser-compatibility: html.elements.video
 examples:
-    - title: Simple video example
-      html-source: examples/simple-video-example/example.html
-      description: examples/simple-video-example/description.md
-      size:
-          width: 640
-          height: 370
-    - title: Multiple sources example
-      html-source: examples/multiple-sources-example/example.html
-      description: examples/multiple-sources-example/description.md
-      size:
-          width: 640
-          height: 370
+  - title: Simple video example
+    html-source: examples/simple-video-example/example.html
+    description: examples/simple-video-example/description.md
+    size:
+      width: 640
+      height: 370
+  - title: Multiple sources example
+    html-source: examples/multiple-sources-example/example.html
+    description: examples/multiple-sources-example/description.md
+    size:
+      width: 640
+      height: 370
 attributes:
-    element-specific: ./attributes
-    global-attributes: /content/html/global_attributes
+  element-specific: ./attributes
+  global-attributes: /content/html/global_attributes
 ```
 
 First we specify that the builder should use the `html-element` recipe to build this page. That's also a promise that the rest of this file contains all the data needed to build all the `meta` sections of that recipe.
@@ -191,17 +192,17 @@ Next are some quite generic items: `title`, `mdn-url`, and `tags`.
 
 The names of the remaining properties match items in the `html-example.yaml` recipe file:
 
-* `dom-interface`, `permitted-aria-roles`, and `tag_omission` are used to populate the HTML element info-box.
+- `dom-interface`, `permitted-aria-roles`, and `tag_omission` are used to populate the HTML element info-box.
 
-* `interactive-example` is the URL where the interactive example can be found.
+- `interactive-example` is the URL where the interactive example can be found.
 
-* `specifications` lists all the specifications for this item.
+- `specifications` lists all the specifications for this item.
 
-* `browser-compatibility` is the browser-compat query for the item. This may contain more than one item, since some pages (e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/gap#Browser_compatibility) contain more than one compat table.
+- `browser-compatibility` is the browser-compat query for the item. This may contain more than one item, since some pages (e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/gap#Browser_compatibility) contain more than one compat table.
 
-* `examples` describes all the live examples in this page, listed in the order that they should be included.
+- `examples` describes all the live examples in this page, listed in the order that they should be included.
 
-* `attributes` is reference to more information about this element's attributes.
+- `attributes` is reference to more information about this element's attributes.
 
 Note that these items are handled in an entirely custom way. This means that the way, for example, that `browser-compatibility` is handled is completely different from the way `interactive-example` is handled. So these kinds of items are very analogous to KumaScript macro calls.
 
@@ -219,17 +220,17 @@ Examples can also have an optional `description`, which is just a Markdown file.
 
 #### Representing attributes
 
-For HTML elements, attributes are *not* just treated as prose: they are given a structured representation. So the `attributes` property in `meta.yaml` points to:
+For HTML elements, attributes are _not_ just treated as prose: they are given a structured representation. So the `attributes` property in `meta.yaml` points to:
 
-* a place the builder can find the global attributes
-* a place the builder can find the element-specific attributes
+- a place the builder can find the global attributes
+- a place the builder can find the element-specific attributes
 
 In those locations the builder will find a number of Markdown files. Each Markdown file starts with a metadata item `browser-compatibility` telling us where to get compat data for this attribute. After this the file describes the attribute using a defined structure that enables the builder to extract, for each attribute:
 
-* name
-* type
-* allowed values
-* general description
+- name
+- type
+- allowed values
+- general description
 
 This is a place where we trade off ease-of-writing against structure. We want HTML element attributes to be machine readable, so an editor could list the possible attributes for a given element. So we separate them out, and move a little in the direction of "form-filling" and a little away from the "holistic source document" ideal.
 
@@ -241,24 +242,28 @@ This means we must have a way to break up a Markdown file into named sections, a
 
 ```html
 <!-- <short-description> -->
-The **HTML Video element** (**`<video>`**) embeds a media player which
-supports video playback into the document.
-<!-- </short-description> -->
+The **HTML Video element** (**`<video>
+  `**) embeds a media player which supports video playback into the document.
+  <!-- </short-description> -->
 
-<!-- <overview> -->
-You can use `<video>` for audio content as well, but the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
-element may provide a more appropriate user experience.
-....
-<!-- </overview> -->
+  <!-- <description> -->
+  You can use `<video>
+    ` for audio content as well, but the [`<audio>
+      `](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
+      element may provide a more appropriate user experience. ....
+      <!-- </description> -->
+    </audio>
+  </video>
+</video>
 ```
 
 #### Optional and wildcard sections
 
 The specification of `prose.` items in the recipe can use a couple of extra features that give authors a little more flexibility.
 
-* In the recipe some sections get a question mark, like `- prose.accessibility-concerns?`. These are optional sections. If a given item doesn't include this section, the builder skips it.
+- In the recipe some sections get a question mark, like `- prose.accessibility-concerns?`. These are optional sections. If a given item doesn't include this section, the builder skips it.
 
-* You can also include an item like `-prose.*`. This means: "include at this point any other marked sections out of prose.md, in the order they appear". This enables authors to include extra sections in the doc at a specific point.
+- You can also include an item like `-prose.*`. This means: "include at this point any other marked sections out of prose.md, in the order they appear". This enables authors to include extra sections in the doc at a specific point.
 
 ## A CSS property example
 
@@ -266,20 +271,20 @@ We've also sketched out how we might define a CSS property in this system. The p
 
 ```yaml
 body:
-- prose.short-description
-- meta.interactive-example
-- prose.overview
-- prose.syntax
-- meta.formal-syntax
-- prose.*
-- prose.accessibility-concerns?
-- meta.examples
-- meta.info-box:
-    - meta.animatable
-    - meta.initial-value
-- meta.specifications
-- meta.browser-compatibility
-- prose.see-also
+  - prose.short-description
+  - meta.interactive-example
+  - prose.description?
+  - prose.syntax
+  - meta.formal-syntax
+  - prose.*
+  - prose.accessibility-concerns?
+  - meta.examples
+  - meta.info-box:
+      - meta.animatable
+      - meta.initial-value
+  - meta.specifications
+  - meta.browser-compatibility
+  - prose.see-also
 ```
 
 This is quite similar to the html-element recipe above, with just a few extra sections for things like formal syntax.
@@ -291,24 +296,25 @@ recipe: css-property
 title: transform
 mdn-url: https://developer.mozilla.org/docs/Web/CSS/transform
 interactive-example: https://interactive-examples.mdn.mozilla.net/pages/css/transform.html
-formal-syntax: 'none | <transform-list>'
+formal-syntax: "none | <transform-list>"
 animatable: true
 initial-value: none
 specifications:
-    - link: https://drafts.csswg.org/css-transforms-2/#transform-functions
-      name: CSS Transforms Level 2
-      status: Editor's Draft
-    - link: https://drafts.csswg.org/css-transforms/#transform-property
-      name: CSS Transforms Level 1
-      status: Working Draft
+  - link: https://drafts.csswg.org/css-transforms-2/#transform-functions
+    name: CSS Transforms Level 2
+    status: Editor's Draft
+  - link: https://drafts.csswg.org/css-transforms/#transform-property
+    name: CSS Transforms Level 1
+    status: Working Draft
 browser-compatibility: css.properties.transform
 examples:
-    - html-source: examples/simple-transform-example/example.html
-      css-source: examples/simple-transform-example/example.css
-      size:
-          width: 400
-          height: 160
+  - html-source: examples/simple-transform-example/example.html
+    css-source: examples/simple-transform-example/example.css
+    size:
+      width: 400
+      height: 160
 ```
+
 ## Additional notes
 
 ### The MDN API
@@ -327,9 +333,9 @@ We can only really test these risks by analysing more pages and more page types.
 
 We can distinguish 2 types of KumaScript macros:
 
-* "block" macros, that construct a complete section of a document. For example, `Compat.ejs`, `EmbedInteractiveExample.ejs`, `EmbedLiveSample.ejs`, `cssinfo.ejs`. These are replaced quite precisely with `meta.` sections.
+- "block" macros, that construct a complete section of a document. For example, `Compat.ejs`, `EmbedInteractiveExample.ejs`, `EmbedLiveSample.ejs`, `cssinfo.ejs`. These are replaced quite precisely with `meta.` sections.
 
-* "inline" macros, that appear in the flow of the prose. The most common of these are the XRef macros, but badges are also inline. These macros are not replaced in this system. With the docs in GitHub rather than the Kuma database it would be much easier to do global search and replace operation if we do want to change, for example, a lot of links at a time: this to some extent makes up for some of the benefits of XRef macros.
+- "inline" macros, that appear in the flow of the prose. The most common of these are the XRef macros, but badges are also inline. These macros are not replaced in this system. With the docs in GitHub rather than the Kuma database it would be much easier to do global search and replace operation if we do want to change, for example, a lot of links at a time: this to some extent makes up for some of the benefits of XRef macros.
 
 ### Omissions
 

--- a/project-docs/stumptown-writers-guide.md
+++ b/project-docs/stumptown-writers-guide.md
@@ -1,16 +1,17 @@
 # Writers' guide to stumptown
 
 **Table of contents:**
-* [stumptown-content and stumptown-renderer](#stumptown-content-and-stumptown-renderer)
-* [The content directory](#the-content-directory)
-* [Recipe files](#recipe-files)
-* [Meta ingredient details](#meta-ingredient-details)
-* [Landing pages](#landing-pages)
-* [Guide pages](#guide-pages)
-* [Related content](#related-content)
-* [Chapter lists](#chapter-lists)
-* [Specifications](#specifications-1)
-* [Contributors](#contributors)
+
+- [stumptown-content and stumptown-renderer](#stumptown-content-and-stumptown-renderer)
+- [The content directory](#the-content-directory)
+- [Recipe files](#recipe-files)
+- [Meta ingredient details](#meta-ingredient-details)
+- [Landing pages](#landing-pages)
+- [Guide pages](#guide-pages)
+- [Related content](#related-content)
+- [Chapter lists](#chapter-lists)
+- [Specifications](#specifications-1)
+- [Contributors](#contributors)
 
 ## stumptown-content and stumptown-renderer
 
@@ -18,9 +19,9 @@ This document describes stumptown from the point of view of a technical writer.
 
 We can think of the MDN documentation landscape like this:
 
--   there are _technical writers_, who are humans skilled in expressing technical concepts. They create content (open Web documentation).
+- there are _technical writers_, who are humans skilled in expressing technical concepts. They create content (open Web documentation).
 
--   there are _consumers_ of this content, which are software components that take this content and present it to human users. A website like developer.mozilla.org is a consumer of this content, but so potentially are devtools or text editors.
+- there are _consumers_ of this content, which are software components that take this content and present it to human users. A website like developer.mozilla.org is a consumer of this content, but so potentially are devtools or text editors.
 
 Accordingly, stumptown is implemented in two Git repositories, ["stumptown-content"](https://github.com/mdn/stumptown-content) and ["stumptown-renderer"](https://github.com/mdn/stumptown-renderer).
 
@@ -61,7 +62,7 @@ The **HTML Bring Attention To element** (**`<b>`**) is used to draw the
 reader's attention to the element's contents, which are not otherwise
 granted special importance.
 
-## Overview
+## Description
 
 This was formerly known as the
 **Boldface element**, and most browsers still draw the text in boldface.
@@ -77,8 +78,8 @@ This was formerly known as the
 
 The file is in 2 main parts:
 
--   a YAML front matter section
--   a Markdown prose section
+- a YAML front matter section
+- a Markdown prose section
 
 The prose section has a number of H2 headings: these divide the document into top-level sections.
 
@@ -90,11 +91,11 @@ All files that can be built as MDN pages contain a `recipe` property, and its va
 
 Recipes are central to stumptown.
 
--   they provide a kind of high-level meta-documentation for writers, explaining concisely what a particular type of page must contain
+- they provide a kind of high-level meta-documentation for writers, explaining concisely what a particular type of page must contain
 
--   they help the linter enforce a particular structure for page types
+- they help the linter enforce a particular structure for page types
 
--   they describe not just what a page contains, but the order in which items should appear in the rendered page.
+- they describe not just what a page contains, but the order in which items should appear in the rendered page.
 
 Let's look at ./recipes/html-element.yaml:
 
@@ -103,7 +104,7 @@ related_content: /content/related_content/html.yaml
 body:
 - prose.short_description
 - meta.interactive_example?
-- prose.overview
+- prose.description?
 - prose.attributes_text?
 - meta.attributes
 - prose.styling?
@@ -124,8 +125,8 @@ The other item, `body`, describes the structure of the page content. Each proper
 
 We said before that a docs file was split into two parts: YAML front matter and Markdown prose. Correspondingly, ingredients in the recipe's `body` have one of two prefixes:
 
--   `meta.` ingredients are supplied by the YAML front matter
--   `prose.` ingredients are supplied by the Markdown prose
+- `meta.` ingredients are supplied by the YAML front matter
+- `prose.` ingredients are supplied by the Markdown prose
 
 Ingredients with a `?` suffix are optional.
 
@@ -151,13 +152,13 @@ short_title: <b>
 mdn_url: /en-US/docs/Web/HTML/Element/b
 specifications: https://html.spec.whatwg.org/multipage/semantics.html#the-b-element
 interactive_example:
-    url: https://interactive-examples.mdn.mozilla.net/pages/tabbed/b.html
-    height: html-short
+  url: https://interactive-examples.mdn.mozilla.net/pages/tabbed/b.html
+  height: html-short
 browser_compatibility: html.elements.b
 examples:
-    - examples/simple-b-example
+  - examples/simple-b-example
 attributes:
-    global: /content/html/global_attributes
+  global: /content/html/global_attributes
 recipe: html-element
 ---
 
@@ -185,7 +186,7 @@ Here are just the prose ingredients from the recipe:
 
 ```
 - prose.short_description
-- prose.overview
+- prose.description
 - prose.attributes_text?
 - prose.styling?
 - prose.accessibility_concerns?
@@ -204,7 +205,7 @@ The **HTML Bring Attention To element** (**`<b>`**) is used to draw the
 reader's attention to the element's contents, which are not otherwise
 granted special importance.
 
-## Overview
+## Description
 
 This was formerly known as the
 **Boldface element**, and most browsers still draw the text in boldface.
@@ -244,15 +245,15 @@ A string that's used by the renderer to set the URL for the docs page to build. 
 
 An object used to specify an interactive example to include in the page. The object contains two properties:
 
--   `url`: URL for the build interactive example, e.g. `https://interactive-examples.mdn.mozilla.net/pages/tabbed/abbr.html`
--   `height`: String determining which height to select for the iframe. This may be any of:
-    -   "js-short"
-    -   "js-standard"
-    -   "js-tall"
-    -   "css-standard"
-    -   "html-short"
-    -   "html-standard"
-    -   "html-tall"
+- `url`: URL for the build interactive example, e.g. `https://interactive-examples.mdn.mozilla.net/pages/tabbed/abbr.html`
+- `height`: String determining which height to select for the iframe. This may be any of:
+  - "js-short"
+  - "js-standard"
+  - "js-tall"
+  - "css-standard"
+  - "html-short"
+  - "html-standard"
+  - "html-tall"
 
 ### attributes
 
@@ -260,27 +261,27 @@ An object that's used to describe which HTML attributes the item supports.
 
 The `attributes` ingredient contains two properties:
 
--   `global`: Mandatory. This is a path to a directory containing the global attributes.
--   `element-specific`: Optional. This may be either:
-    -   a path to a directory containing the element-specific attributes.
-    -   an array of file paths, each of which contains documentation for a single attribute.
+- `global`: Mandatory. This is a path to a directory containing the global attributes.
+- `element-specific`: Optional. This may be either:
+  - a path to a directory containing the element-specific attributes.
+  - an array of file paths, each of which contains documentation for a single attribute.
 
 For example:
 
 ```yaml
 attributes:
-    element_specific: ./attributes
-    global: /content/html/global_attributes
+  element_specific: ./attributes
+  global: /content/html/global_attributes
 ```
 
 In this example, there should be an "attributes" subdirectory of the directory containing this front matter, and it contains files describing the element-specific attributes.
 
 ```yaml
 attributes:
-    element_specific:
-        - ../input/attributes/autocomplete.md
-        - ../input/attributes/name.md
-    global: /content/html/global_attributes
+  element_specific:
+    - ../input/attributes/autocomplete.md
+    - ../input/attributes/name.md
+  global: /content/html/global_attributes
 ```
 
 In this example, there are two element-specific attributes, found at "../input/attributes/autocomplete.md" and "../input/attributes/name.md", relative to the directory containing this front matter.
@@ -322,8 +323,8 @@ String
 
 The file may contain some YAML front matter, with the following two properties, both optional:
 
--   `browser_compatibility`: syntax is the same as the `browser_compatibility` ingredient
--   `specifications`: syntax is the same as the `specifications` ingredient.
+- `browser_compatibility`: syntax is the same as the `browser_compatibility` ingredient
+- `specifications`: syntax is the same as the `specifications` ingredient.
 
 The H1 heading must be in `code format` and its content must be the name of the attribute:
 
@@ -365,9 +366,9 @@ It is given as an array of paths to directories. Each directory contains a singl
 
 ```yaml
 examples:
-    - examples/simple-example
-    - examples/audio-element-with-video-element
-    - examples/multiple-source-elements
+  - examples/simple-example
+  - examples/audio-element-with-video-element
+  - examples/multiple-source-elements
 ```
 
 **Note: it looks like this is using a different path convention from attributes. We should be consistent here. Filed as https://github.com/mdn/stumptown-content/issues/204.**
@@ -376,10 +377,10 @@ Examples will be included in the rendered output in the order given here: so for
 
 Each example is specified as a directory containing four files, one mandatory and three optional:
 
--   "description.md" - the only mandatory one
--   "example.html"
--   "example.css"
--   "example.js"
+- "description.md" - the only mandatory one
+- "example.html"
+- "example.css"
+- "example.js"
 
 **Note: we don't yet support "hidden" sources One suggestion was just to call them "hidden.css" etc. Filed as https://github.com/mdn/stumptown-content/issues/205.**
 
@@ -416,9 +417,9 @@ This property lists specifications for the item.
 
 This is given as one of:
 
--   the string "non-standard"
--   a single URL
--   an array of URLs
+- the string "non-standard"
+- a single URL
+- an array of URLs
 
 URLs must match one of the URLs listed in "specifications.yaml" (see the "Specifications" section), where "match" means they fully contain it, although they may add additional path or hash items. For example:
 
@@ -460,11 +461,11 @@ This is specified as an array of "link list" objects. Each of these objects will
 
 Each "link list" object may be specified in one of three ways:
 
--   as a directory. An object that consists of two properties: `title`, which is a string that will be used as the list title, and `directory`, which is a path to a directory. Stumptown will look for all pages immediately inside the given directory, and make links to them. For example, if you give it "/content/html/reference/elements" it will make a list of all the HTML elements.
+- as a directory. An object that consists of two properties: `title`, which is a string that will be used as the list title, and `directory`, which is a path to a directory. Stumptown will look for all pages immediately inside the given directory, and make links to them. For example, if you give it "/content/html/reference/elements" it will make a list of all the HTML elements.
 
--   as an explicit list of pages. An object that consists of two properties: `title`, which is a string that will be used as the list title, and `pages`, which is an array of paths to pages. Stumptown will make links to all the pages listed.
+- as an explicit list of pages. An object that consists of two properties: `title`, which is a string that will be used as the list title, and `pages`, which is an array of paths to pages. Stumptown will make links to all the pages listed.
 
--   as a `chapter_list`. An object that consists of one property: `chapter_list`, which is a path to a "Chapter list" YAML file. Stumptown will make links to all the pages listed in the chapter_list. This is really just a reusable version of the explicit list of pages.
+- as a `chapter_list`. An object that consists of one property: `chapter_list`, which is a path to a "Chapter list" YAML file. Stumptown will make links to all the pages listed in the chapter_list. This is really just a reusable version of the explicit list of pages.
 
 For example:
 
@@ -481,9 +482,9 @@ link_lists:
 
 This specifies three link lists.
 
--   The first has the title "Index of HTML elements" and contains links to all the pages under "/content/html/reference/elements".
--   The second has the title "Some guide pages", and contains links to the two pages listed.
--   the third as the title and link list that's given in the referenced chapter list.
+- The first has the title "Index of HTML elements" and contains links to all the pages under "/content/html/reference/elements".
+- The second has the title "Some guide pages", and contains links to the two pages listed.
+- the third as the title and link list that's given in the referenced chapter list.
 
 ## Landing pages
 
@@ -507,12 +508,12 @@ specifications: https://html.spec.whatwg.org/multipage/
 recipe: landing-page
 related_content: /content/related_content/html.yaml
 link_lists:
-    - title: Learn HTML
-      pages:
-          - "/content/learn/html/Introduction_to_HTML"
-    - title: Reference
-      pages:
-          - "/content/html/reference/elements"
+  - title: Learn HTML
+    pages:
+      - "/content/learn/html/Introduction_to_HTML"
+  - title: Reference
+    pages:
+      - "/content/html/reference/elements"
 ---
 
 ```
@@ -555,9 +556,9 @@ The Markdown part is of course the guide's prose. To support the "special conten
 
 We currently support two directives:
 
-* "embed-example": this tells stumptown that the guide wants to embed a live sample at this point. Its argument is "examples/specifying-colors-in-stylesheets", which is a path to a directory containing an example. The content of this directory is just the same as the directories references by the `examples` front matter property, with a mandatory "description.md" and optional "example.[html|css|js]" files.
+- "embed-example": this tells stumptown that the guide wants to embed a live sample at this point. Its argument is "examples/specifying-colors-in-stylesheets", which is a path to a directory containing an example. The content of this directory is just the same as the directories references by the `examples` front matter property, with a mandatory "description.md" and optional "example.[html|css|js]" files.
 
-* "embed-compat": this tells stumptown that the guide wants to embed a BCD table at this point. Its argument is a BCD query string like "html.elements.audio".
+- "embed-compat": this tells stumptown that the guide wants to embed a BCD table at this point. Its argument is a BCD query string like "html.elements.audio".
 
 We will probably add support for more directives in future, not too many. One likely candidate would be "embed-link-list".
 
@@ -577,54 +578,54 @@ Each collection of related content is described in a special YAML file. All "rel
 
 It's specified as an array of objects. Each object describes a section of the related content. A section has two properties:
 
-* `title`: the name of this section
-* `directory` or `chapter_list` or `pages` or `children`:
-    * if `directory`, then this section contains links to all pages in the given directory
-    * if `chapter_list` then this section contains links to all pages as specified in the given chapter list
-    * if `pages` then this section contains links to all pages listed explicitly
-    * if `children`, then this section itself contains sections: this enables you to nest groups of links to an arbitrary depth.
+- `title`: the name of this section
+- `directory` or `chapter_list` or `pages` or `children`:
+  - if `directory`, then this section contains links to all pages in the given directory
+  - if `chapter_list` then this section contains links to all pages as specified in the given chapter list
+  - if `pages` then this section contains links to all pages listed explicitly
+  - if `children`, then this section itself contains sections: this enables you to nest groups of links to an arbitrary depth.
 
 So for example, here's a "related content" file for HTML:
 
 ```yaml
 - title: Learn HTML
   children:
-  - chapter_list: "/content/learn/html/Introduction_to_HTML.yaml"
-  - chapter_list: "/content/learn/html/Multimedia_and_embedding.yaml"
+    - chapter_list: "/content/learn/html/Introduction_to_HTML.yaml"
+    - chapter_list: "/content/learn/html/Multimedia_and_embedding.yaml"
 - title: Guides
   children:
-  - chapter_list: "/content/html/guides/Guides.yaml"
+    - chapter_list: "/content/html/guides/Guides.yaml"
 - title: Reference
   children:
-  - title: Elements
-    directory: "/content/html/reference/elements"
-  - title: Global attributes
-    directory: "/content/html/reference/attributes"
+    - title: Elements
+      directory: "/content/html/reference/elements"
+    - title: Global attributes
+      directory: "/content/html/reference/attributes"
 ```
 
 It consists of three top-level sections.
 
-* The first section "Learn HTML" consists of two subsections, each specified using a chapter list ("Introduction_to_HTML.yaml" and "Multimedia_and_embedding.yaml").
+- The first section "Learn HTML" consists of two subsections, each specified using a chapter list ("Introduction_to_HTML.yaml" and "Multimedia_and_embedding.yaml").
 
-* The second section "Guides" consists of one subsection, specified using a chapter list ("Guides.yaml").
+- The second section "Guides" consists of one subsection, specified using a chapter list ("Guides.yaml").
 
-* The third section "Reference" consists of two subsections, each specified using a directory ("/content/html/reference/elements" and "/content/html/reference/attributes").
+- The third section "Reference" consists of two subsections, each specified using a directory ("/content/html/reference/elements" and "/content/html/reference/attributes").
 
 The resulting structure looks like:
 
-* Learn HTML
-    * Introduction to HTML
-        * ... all Introduction to HTML chapters
-    * Multimedia and embedding
-        * ... all Multumedia and embedding chapters
-* Guides
-    * HTML guides
-        * ...all HTML guide pages
-* Reference
-    * Elements
-        * ...all HTML element pages
-    * Global attributes
-        * ...all HTML global attribute pages
+- Learn HTML
+  - Introduction to HTML
+    - ... all Introduction to HTML chapters
+  - Multimedia and embedding
+    - ... all Multumedia and embedding chapters
+- Guides
+  - HTML guides
+    - ...all HTML guide pages
+- Reference
+  - Elements
+    - ...all HTML element pages
+  - Global attributes
+    - ...all HTML global attribute pages
 
 These related content files are referenced using the `related_content` property. This may appear either in recipes (for page types that all want the same related content collection), or in the front matter section of individual pages (for page types, like guides and landing pages, that don't all want the same related content collection).
 
@@ -638,8 +639,8 @@ A "chapter list" is just a way to provide a reusable list of links to pages, pre
 
 A chapter list is a YAML file with the following contents:
 
--   `title`: a mandatory property whose value is a string. This provides a title for the list.
--   `chapters`: an array of paths to pages to include, relative to the location of the chapter list itself.
+- `title`: a mandatory property whose value is a string. This provides a title for the list.
+- `chapters`: an array of paths to pages to include, relative to the location of the chapter list itself.
 
 For example, the chapter list for HTML guides, which is at content/html/guides:
 
@@ -672,10 +673,10 @@ Here's an example:
 # Allowed specification domains and their titles
 # Never add historical specfications to this allow list
 
-html.spec.whatwg.org: 'WHATWG HTML Living Standard'
-w3c.github.io/webappsec-cspee: 'Content Security Policy: Embedded Enforcement'
-w3c.github.io/webappsec-feature-policy: 'Feature Policy'
-wicg.github.io/priority-hints: 'Priority Hints'
+html.spec.whatwg.org: "WHATWG HTML Living Standard"
+w3c.github.io/webappsec-cspee: "Content Security Policy: Embedded Enforcement"
+w3c.github.io/webappsec-feature-policy: "Feature Policy"
+wicg.github.io/priority-hints: "Priority Hints"
 ```
 
 Items listed in the `specifications` front matter property must match one of the URLs in this file. They may add extra path elements and fragments, to point to individual items within a specification:

--- a/recipes/css-property.yaml
+++ b/recipes/css-property.yaml
@@ -5,7 +5,7 @@ data:
 body:
   - prose.short_description
   - data.interactive_example
-  - prose.overview
+  - prose.description?
   - prose.syntax_overview
   - prose.example_syntax
   - data.formal_syntax

--- a/recipes/html-element.yaml
+++ b/recipes/html-element.yaml
@@ -6,7 +6,7 @@ data:
 body:
   - prose.short_description
   - data.interactive_example?
-  - prose.overview
+  - prose.description?
   - prose.attributes_text?
   - data.attributes
   - prose.styling?

--- a/recipes/html-input-element.yaml
+++ b/recipes/html-input-element.yaml
@@ -6,7 +6,7 @@ data:
 body:
   - prose.short_description
   - data.interactive_example?
-  - prose.overview
+  - prose.description?
   - prose.value
   - prose.validation
   - prose.attributes_text?

--- a/recipes/javascript-constructor.yaml
+++ b/recipes/javascript-constructor.yaml
@@ -7,7 +7,7 @@ body:
   - prose.short_description
   - data.interactive_example?
   - prose.syntax
-  - prose.description
+  - prose.description?
   - prose.*
   - data.examples
   - data.specifications

--- a/recipes/javascript-language-feature.yaml
+++ b/recipes/javascript-language-feature.yaml
@@ -7,7 +7,7 @@ body:
   - prose.short_description
   - data.interactive_example?
   - prose.syntax
-  - prose.description
+  - prose.description?
   - prose.*
   - data.examples
   - data.specifications

--- a/recipes/javascript-method.yaml
+++ b/recipes/javascript-method.yaml
@@ -7,7 +7,7 @@ body:
   - prose.short_description
   - data.interactive_example?
   - prose.syntax
-  - prose.description
+  - prose.description?
   - prose.*
   - data.examples
   - data.specifications

--- a/recipes/javascript-property.yaml
+++ b/recipes/javascript-property.yaml
@@ -6,7 +6,7 @@ data:
 body:
   - prose.short_description
   - data.interactive_example?
-  - prose.description
+  - prose.description?
   - data.info_box
   - prose.*
   - data.examples

--- a/recipes/landing-page.yaml
+++ b/recipes/landing-page.yaml
@@ -3,5 +3,5 @@ data:
   - short_title?
   - mdn_url
 body:
-  - prose.overview
+  - prose.description?
   - data.link_lists

--- a/scripts/build-json/slice-prose.js
+++ b/scripts/build-json/slice-prose.js
@@ -4,7 +4,7 @@ const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 const namedSections = [
   "Short description",
-  "Overview",
+  "Description",
   "Attributes",
   "Usage notes",
   "Accessibility concerns",


### PR DESCRIPTION
Makes "Description" sections optional throughout JS docs. When linting the whole JS tree:

Before:

```
Missing from javascript-method: prose.description                             143 errors     javascript-method/prose.description    
Missing from javascript-constructor: prose.description                        63 errors      javascript-constructor/prose.description   
Missing from javascript-property: prose.description                           22 errors      javascript-property/prose.description                                  
Missing from javascript-language-feature: prose.description                   19 errors      javascript-language-feature/prose.description                          
74 message types (9737 messages, ✖ 800 errors, ⚠ 8937 warnings) in 919 files
```

After:
```
70 message types (9490 messages, ✖ 553 errors, ⚠ 8937 warnings) in 919 files
```


I believe we should make description sections optional. Of course, this raises the question to authors when to have a "Description" section and when not. Currently, I believe, it is there when the method or any language feature needs more explanations that doesn't fit into the short description. Not all pages need these longer texts, though. Sometimes what's in "Description" could probably be put into (multiple) examples, but sometimes it is really just text and not code. So, my feeling is that the "Description" section is a bit like a guide page as a section in the reference. The author can freely make use of it to go deeper and explain concepts etc. More thoughts on this welcome.

Follows up on the comment I made here https://github.com/mdn/stumptown-content/issues/348#issuecomment-600036084