### PR TITLE
Add a linter test to warn if pages contain H2 headings not in the recipe

### DIFF
--- a/scripts/scraper-ng/preset.js
+++ b/scripts/scraper-ng/preset.js
@@ -12,5 +12,6 @@ module.exports = {
     [require("./rules/file-require-recipe")],
     [require("./rules/html-no-macros"), allowedMacros],
     [require("./rules/html-require-recipe-ingredients")],
+    [require("./rules/html-warn-unknown-headings")],
   ],
 };

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
@@ -1,8 +1,6 @@
-const fs = require("fs");
 const path = require("path");
 
-const yaml = require("js-yaml");
-
+const { loadRecipe } = require("../utils.js");
 const ingredientHandlers = require("./ingredient-handlers");
 const { Logger } = require("./ingredient-handlers/utils");
 
@@ -31,26 +29,6 @@ function requireRecipeIngredientsPlugin() {
       }
     }
   };
-}
-
-const recipesCache = {};
-
-/**
- * Load a recipe object from a path.
- *
- * @param {String} path - the path to a recipe YAML file
- * @returns {Object} - the loaded recipe object
- */
-function loadRecipe(path) {
-  if (path === undefined) {
-    return undefined;
-  }
-
-  if (recipesCache[path] === undefined) {
-    recipesCache[path] = yaml.safeLoad(fs.readFileSync(path));
-  }
-
-  return recipesCache[path];
 }
 
 module.exports = requireRecipeIngredientsPlugin;

--- a/scripts/scraper-ng/rules/html-warn-unknown-headings.js
+++ b/scripts/scraper-ng/rules/html-warn-unknown-headings.js
@@ -28,8 +28,8 @@ function warnUnknownHeadings() {
 }
 
 function expectedH2Headings(recipeBody) {
+  // exclude any ingredients that don't map to H2 headings
   const namedProseSections = recipeBody.filter(
-    // exclude any ingredients that don't map to H2 headings
     (ingredient) =>
       ingredient !== "prose.*" &&
       ingredient !== "prose.short_description" &&

--- a/scripts/scraper-ng/rules/html-warn-unknown-headings.js
+++ b/scripts/scraper-ng/rules/html-warn-unknown-headings.js
@@ -1,0 +1,46 @@
+const path = require("path");
+
+const { selectAll } = require("hast-util-select");
+
+const { loadRecipe } = require("./utils.js");
+
+const source = "html-warn-unknown-headings";
+
+/**
+ * Emit warnings when a page contains H2 headings that don't
+ * correspond to ingredients in the page's recipe.
+ */
+function warnUnknownHeadings() {
+  return function attacher(tree, file) {
+    const recipeName = path.basename(file.data.recipePath, ".yaml");
+    const recipe = loadRecipe(file.data.recipePath);
+    const expectedH2 = expectedH2Headings(recipe.body);
+    const actualH2 = selectAll(`h2`, tree);
+    for (const actual of actualH2) {
+      if (!expectedH2.includes(actual.properties.id)) {
+        file.message(
+          `H2 heading: ${actual.properties.id} was not in recipe`,
+          `${source}:${recipeName}/unknown-heading`
+        );
+      }
+    }
+  };
+}
+
+function expectedH2Headings(recipeBody) {
+  const namedProseSections = recipeBody.filter(
+    // exclude any ingredients that don't map to H2 headings
+    (ingredient) =>
+      ingredient !== "prose.*" &&
+      ingredient !== "prose.short_description" &&
+      ingredient !== "data.interactive_example?"
+  );
+  return namedProseSections.map((namedProse) => {
+    let result = namedProse.replace(/^.*\./, ""); // remove "<prefix>."
+    result = result.replace(/\?$/, ""); // remove optional "?"
+    result = result[0].toUpperCase() + result.slice(1); // capitalize initial
+    return result;
+  });
+}
+
+module.exports = warnUnknownHeadings;

--- a/scripts/scraper-ng/rules/html-warn-unknown-headings.js
+++ b/scripts/scraper-ng/rules/html-warn-unknown-headings.js
@@ -20,6 +20,7 @@ function warnUnknownHeadings() {
       if (!expectedH2.includes(actual.properties.id)) {
         file.message(
           `H2 heading: ${actual.properties.id} was not in recipe`,
+          actual,
           `${source}:${recipeName}/unknown-heading`
         );
       }

--- a/scripts/scraper-ng/rules/utils.js
+++ b/scripts/scraper-ng/rules/utils.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+
+const yaml = require("js-yaml");
+
+const recipesCache = {};
+
+/**
+ * Load a recipe object from a path.
+ *
+ * @param {String} path - the path to a recipe YAML file
+ * @returns {Object} - the loaded recipe object
+ */
+function loadRecipe(path) {
+  if (path === undefined) {
+    return undefined;
+  }
+
+  if (recipesCache[path] === undefined) {
+    recipesCache[path] = yaml.safeLoad(fs.readFileSync(path));
+  }
+
+  return recipesCache[path];
+}
+
+module.exports = {
+  loadRecipe,
+};


### PR DESCRIPTION
With https://github.com/mdn/stumptown-content/pull/374 it became clear that we won't actually lint many classes for their members, because they aren't using the "proper" H2 headings as listed in the recipe. Because these ingredients are optional, we don't consider this a failure.

This PR is an attempt to help out with that: it makes us emit warnings for H2 headings that don't map to any ingredients in the recipe. These headings are not necessarily errors (unless `prose.*` is absent) but might be a useful clue about pages where headings are wrong. For example, running it on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date will give us:

```
1:1  warning  H2 heading: Constructor was not in recipe               javascript-class/unknown-heading                                    html-warn-unknown-headings
1:1  warning  H2 heading: Date_instances was not in recipe            javascript-class/unknown-heading                                    html-warn-unknown-headings
1:1  warning  H2 heading: Methods was not in recipe                   javascript-class/unknown-heading                                    html-warn-unknown-headings
1:1  warning  H2 heading: Properties was not in recipe                javascript-class/unknown-heading                                    html-warn-unknown-headings
```

The last three of these all look like errors in the page, but I think we should treat the first as an error in the recipe. This test has a simple-minded mapping from ingredients to H2 headings: slice off the prefix and "?" suffix, and capitalize the remainder. This breaks for the `data.class_constructor` ingredient, which ought to map to just "Constructor". I like the simple-minded mapping, and can't think of any reason not to use `data.constructor` as the ingredient name. Looking at [the PR that introduced `data.class_constructor`](https://github.com/mdn/stumptown-content/pull/230) I can't see any reasoning behind that name choice.