### PR TITLE
Rename 'data.class_constructor' to 'data.constructor'

### DIFF
--- a/project-docs/javascript-linter-spec.md
+++ b/project-docs/javascript-linter-spec.md
@@ -58,7 +58,7 @@ prose ingredients:
 data ingredients:
 
 - data.interactive_example?
-- data.class_constructor
+- data.constructor
 - data.constructor_properties?
 - data.static_properties?
 - data.static_methods?
@@ -108,7 +108,7 @@ This is an optional data ingredient. To satisfy the ingredient, either:
 - the page must not contain a `{{EmbedInteractiveExample}}` macro call, or
 - the page must have a `<div>` containing an `{{EmbedInteractiveExample}}` macro call. The `<div>` must be immediately preceded by paragraph that is neither a note nor a warning. The `<div>` must precede any `<h2>`.
 
-#### data.class_constructor
+#### data.constructor
 
 To satisfy this ingredient, a page must meet the following requirements:
 

--- a/recipes/javascript-class.yaml
+++ b/recipes/javascript-class.yaml
@@ -7,7 +7,7 @@ body:
   - prose.short_description
   - data.interactive_example?
   - prose.description?
-  - data.class_constructor
+  - data.constructor
   - data.static_properties?
   - data.static_methods?
   - data.instance_properties?

--- a/scripts/build-json/build-recipe-page-json.js
+++ b/scripts/build-json/build-recipe-page-json.js
@@ -45,7 +45,7 @@ function processMetaIngredient(elementPath, ingredientName, data) {
     case "link_lists": {
       return data.link_lists.map(buildLinkList);
     }
-    case "class_constructor":
+    case "constructor":
       return buildLinkList({
         title: "Constructor",
         pages: [data.class_constructor],


### PR DESCRIPTION
As discussed in https://github.com/mdn/stumptown-content/pull/397, I think we ought to use `data.constructor` to name the "Constructor" ingredient in JavaScript class pages (i.e. to name the page element at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Constructor).
