### PR TITLE
Add ingredient handler for 'data.examples'

### DIFF
--- a/project-docs/javascript-linter-spec.md
+++ b/project-docs/javascript-linter-spec.md
@@ -148,29 +148,14 @@ This is an optional ingredient. It's just the same as `data.constructor_properti
 
 #### data.examples
 
-To satisfy this ingredient a page must have a section demarcated by `H2#Examples`. It must contain one or more sections demarcated by an H3. Each of these sections represents a single example.
+To satisfy this ingredient a page must have a section demarcated by `H2#Examples`. It must contain one or more sections demarcated by an H3. Each of these H3 sections represents a single example.
 
-Each of these examples may include "code sections". These are marked up as follows:
+Each example may be a simple example or a live sample. If the example contains a call to the `{{EmbedLiveSample}}` macro, it is a live sample. Otherwise it is a simple example.
 
-- HTML code section: `<pre class="brush: html language-html"><code class="language-html">`
-- CSS code section: `<pre class="brush: css language-css"><code class=" language-css">`
-- JavaScript code section: `<pre class="brush: js language-js"><code class=" language-js">`
+Live samples must satisfy certain additional constraints:
 
-Examples must follow some rules about which sections may appear and how they are ordered:
-
-- An example may contain zero or one of each type of section.
-- If an example includes a JavaScript code section, it must be the last element in the section.
-- If an example includes a CSS code section, it may only be followed by a JavaScript section.
-- If an example includes an HTML code section, it may only be followed by a CSS section.
-
-Another way to put this is: each example is structured like:
-
-```
-unstructured prose
-optional HTML section
-optional CSS section
-optional JavaScript section
-```
+- The call to `{{EmbedLiveSample}}` must be the last element in the example (the only exception is that text nodes consisting only of newlines may follow the `{{EmbedLiveSample}}` call). This implies that there may only be one live sample in a given H3 section, and that the iframe showing the output must appear last in the rendered page, after any code or explanatory prose.
+- The ID parameter passed to `{{EmbedLiveSample}}` must match the ID of the example's H3 heading. This implies that the example is not allowed to contain any code blocks that are not included in the live sample.
 
 #### data.specifications
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -83,7 +83,7 @@ function handleDataExamples(tree, logger) {
       (node) => node.tagName === "h3",
       examplesSection
     );
-    checkExample(body, exampleSection, logger);
+    checkExample(exampleSection, logger);
   }
 }
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -1,0 +1,90 @@
+const select = require("hast-util-select");
+const visit = require("unist-util-visit");
+
+const utils = require("./utils.js");
+
+/**
+ * Function returning true only if the given node is a text node
+ * that contains only newlines.
+ */
+function isNewlineOnlyTextNode(node) {
+  return node.type === "text" && node.value.match(/^\n*$/);
+}
+
+/**
+ * Checks a single example. This only does any checking for live samples:
+ * that is, examples that contain a call to the EmbedLiveSample macro.
+ */
+function checkExample(body, exampleNodes, logger) {
+  let liveSampleNode = null;
+  visit(exampleNodes, (node) => {
+    // If we have already seen an EmbedLiveSample call...
+    if (liveSampleNode !== null) {
+      // ...then the only nodes allowed after that point are text nodes containing only newlines
+      if (!isNewlineOnlyTextNode(node)) {
+        logger.fail(
+          node,
+          "EmbedLiveSample must be final node",
+          "nodes-after-live-sample"
+        );
+      }
+    }
+    if (utils.isMacro(node, "EmbedLiveSample")) {
+      liveSampleNode = node;
+    }
+  });
+  // If this example didn't contain a call to EmbedLiveSample, there are no further checks
+  if (!liveSampleNode) {
+    return;
+  }
+  // The first child of `exampleNodes` is the title
+  const exampleTitle = exampleNodes.children[0];
+  // The ID argument to the EmbedLiveSample macro must be the ID of the example title
+  if (liveSampleNode.data.macroParams[0] !== exampleTitle.properties.id) {
+    logger.fail(
+      liveSampleNode,
+      "EmbedLiveSample ID argument must match H3 heading ID",
+      "embedlivesample-id-mismatch"
+    );
+  }
+}
+
+/**
+ * Handler for the `data.examples` ingredient.
+ */
+function handleDataExamples(tree, logger) {
+  const id = "Examples";
+  const body = select.select(`body`, tree);
+  const heading = select.select(`h2#${id}`, body);
+
+  // The document must have an H2 section "Examples"
+  if (heading === null) {
+    logger.expected(body, `h2#${id}`, "expected-heading");
+    return;
+  }
+
+  const examplesSection = utils.sliceSection(heading, body);
+  const exampleTitles = select.selectAll("h3", examplesSection);
+
+  // The "Examples" section must contain at least one H3
+  if (exampleTitles.length === 0) {
+    logger.fail(
+      examplesSection,
+      "No H3-demarcated examples found",
+      "missing-example-h3"
+    );
+    return;
+  }
+
+  for (const exampleTitle of exampleTitles) {
+    // Extract and check each example
+    const exampleSection = utils.sliceBetween(
+      exampleTitle,
+      (node) => node.tagName === "h3",
+      examplesSection
+    );
+    checkExample(body, exampleSection, logger);
+  }
+}
+
+module.exports = handleDataExamples;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -64,9 +64,9 @@ function handleDataExamples(tree, logger) {
   }
 
   const examplesSection = utils.sliceSection(heading, body);
-  const exampleTitles = select.selectAll("h3", examplesSection);
 
   // The "Examples" section must contain at least one H3
+  const exampleTitles = select.selectAll("h3", examplesSection);
   if (exampleTitles.length === 0) {
     logger.fail(
       examplesSection,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -15,7 +15,7 @@ function isNewlineOnlyTextNode(node) {
  * Checks a single example. This only does any checking for live samples:
  * that is, examples that contain a call to the EmbedLiveSample macro.
  */
-function checkExample(body, exampleNodes, logger) {
+function checkExample(exampleNodes, logger) {
   let liveSampleNode = null;
   visit(exampleNodes, (node) => {
     // If we have already seen an EmbedLiveSample call...

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -1,6 +1,7 @@
 const { select } = require("hast-util-select");
 
 const handleDataSpecifications = require("./data-specifications");
+const handleDataExamples = require("./data-examples");
 const handleDataBrowserCompatibility = require("./data-browser-compatibility");
 const handleProseShortDescription = require("./prose-short-description");
 const classMembers = require("./data-class-members");
@@ -23,7 +24,7 @@ const classMembers = require("./data-class-members");
  */
 const ingredientHandlers = {
   "data.browser_compatibility": handleDataBrowserCompatibility,
-  "data.examples": requireTopLevelHeading("Examples"),
+  "data.examples": handleDataExamples,
   "data.specifications": handleDataSpecifications,
   "prose.description": requireTopLevelHeading("Description"),
   "prose.error_type": requireTopLevelHeading("Error_type"),

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -27,6 +27,7 @@ const sources = {
   <pre class="brush: css">h1: { color: blue; }</pre>
   {{EmbedLiveSample("An_example")}}
 
+
 <h3 id="Another_example">Another example</h3>
   <p>Some more prose description</p>
   <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -3,9 +3,11 @@ const { process } = require("./framework/utils");
 const sources = {
   valid_single_simple: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An examples</h3>`,
+
   valid_multiple_simple: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
 <h3 id="Another_example">Another example</h3>`,
+
   valid_multiple_live_samples: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
   <p>Some prose description</p>
@@ -17,6 +19,7 @@ const sources = {
   <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
   <pre class="brush: css">h1: { color: red; }</pre>
   {{EmbedLiveSample("Another_example")}}`,
+
   valid_simple_live_mixture: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
   <p>Some prose description</p>
@@ -27,14 +30,18 @@ const sources = {
   <p>Some more prose description</p>
   <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
   <pre class="brush: css">h1: { color: red; }</pre>`,
+
   missing_example_h3: `<h2 id="Examples">Examples</h2>
 <p>blah blah</p>`,
+
   nodes_after_live_sample: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
   {{EmbedLiveSample("An_example")}}Some more content`,
+
   live_sample_id_mismatch: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
   {{EmbedLiveSample("A_different_example")}}`,
+
   empty_source: "",
 };
 

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -1,0 +1,100 @@
+const { process } = require("./framework/utils");
+
+const sources = {
+  valid_single_simple: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An examples</h3>`,
+  valid_multiple_simple: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An example</h3>
+<h3 id="Another_example">Another example</h3>`,
+  valid_multiple_live_samples: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An example</h3>
+  <p>Some prose description</p>
+  <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
+  <pre class="brush: css">h1: { color: blue; }</pre>
+  {{EmbedLiveSample("An_example")}}
+<h3 id="Another_example">Another example</h3>
+  <p>Some more prose description</p>
+  <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
+  <pre class="brush: css">h1: { color: red; }</pre>
+  {{EmbedLiveSample("Another_example")}}`,
+  valid_simple_live_mixture: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An example</h3>
+  <p>Some prose description</p>
+  <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
+  <pre class="brush: css">h1: { color: blue; }</pre>
+  {{EmbedLiveSample("An_example")}}
+<h3 id="Another_example">Another example</h3>
+  <p>Some more prose description</p>
+  <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
+  <pre class="brush: css">h1: { color: red; }</pre>`,
+  missing_example_h3: `<h2 id="Examples">Examples</h2>
+<p>blah blah</p>`,
+  nodes_after_live_sample: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An example</h3>
+  {{EmbedLiveSample("An_example")}}Some more content`,
+  live_sample_id_mismatch: `<h2 id="Examples">Examples</h2>
+<h3 id="An_example">An example</h3>
+  {{EmbedLiveSample("A_different_example")}}`,
+  empty_source: "",
+};
+
+describe("data.examples", () => {
+  const testRecipe = { body: ["data.examples"] };
+
+  test("valid single simple example", () => {
+    const file = process(sources.valid_single_simple, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+  });
+
+  test("valid multiple simple examples", () => {
+    const file = process(sources.valid_multiple_simple, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+  });
+
+  test("valid multiple live samples", () => {
+    const file = process(sources.valid_multiple_live_samples, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file.messages[0].ruleId).toBe("embedlivesample");
+    expect(file.messages[1].ruleId).toBe("embedlivesample");
+  });
+
+  test("valid mixture of simple and live samples", () => {
+    const file = process(sources.valid_simple_live_mixture, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(/embedlivesample/);
+  });
+
+  test("missing Examples H3", () => {
+    const file = process(sources.missing_example_h3, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(/data.examples\/missing-example-h3/);
+  });
+
+  test("live sample is not final node", () => {
+    const file = process(sources.nodes_after_live_sample, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId(/embedlivesample/);
+    expect(file).hasMessageWithId(/data.examples\/nodes-after-live-sample/);
+  });
+
+  test("live sample ID mismatch", () => {
+    const file = process(sources.live_sample_id_mismatch, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId(/embedlivesample/);
+    expect(file).hasMessageWithId(/data.examples\/embedlivesample-id-mismatch/);
+  });
+
+  test("missing heading", () => {
+    const file = process(sources.empty_source, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(/data.examples\/expected-heading/);
+  });
+});

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -26,6 +26,7 @@ const sources = {
   <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>
   <pre class="brush: css">h1: { color: blue; }</pre>
   {{EmbedLiveSample("An_example")}}
+
 <h3 id="Another_example">Another example</h3>
   <p>Some more prose description</p>
   <pre class="brush: html">&lt;h1&gt;A heading&lt;/h1&gt;</pre>

--- a/scripts/scraper-ng/test/javascript-constructor.html
+++ b/scripts/scraper-ng/test/javascript-constructor.html
@@ -30,6 +30,8 @@ BigInt(<em>value</em>);
 
 <h2 id="Examples">Examples</h2>
 
+<h3 id="An_example">An example</h3>
+
 <pre class="brush: js">
 BigInt(123);
 // 123n


### PR DESCRIPTION
This extends the linter to lint examples. It uses the spec described in https://github.com/mdn/stumptown-content/issues/350#issuecomment-617455037, not the one currently in the [doc](https://github.com/mdn/stumptown-content/blob/master/project-docs/javascript-linter-spec.md). So merging it is contingent on agreeing that change to the spec, and updating the doc.

If the testing PR lands before this, I will add some tests as well :).