### PR TITLE
Remove data.info_box

### DIFF
--- a/recipes/javascript-property.yaml
+++ b/recipes/javascript-property.yaml
@@ -7,7 +7,6 @@ body:
   - prose.short_description
   - data.interactive_example?
   - prose.description?
-  - data.info_box
   - prose.*
   - data.examples
   - data.specifications


### PR DESCRIPTION
See https://github.com/mdn/stumptown-content/issues/332#issuecomment-622056087.

We haven't specced linter behavior for the `data.info_box` ingredient of JS properties, because I was thinking we should just treat it as prose for now.

We don't at the moment understand quite how we should [represent "info boxes" in MDN structured content](https://docs.google.com/document/d/1fwbTs6uoeAfGjjZef3cOOzG1Bx-S8sbLbCBjzx9gBPY/edit#). So representing them would involve us in a substantial amount of modelling work. Unlike the CSS info boxes, the boxes in JS property pages are simple tables that don't use any external data source, so we don't _have_ to do anything special (i.e. non-prose-y) with them even when scraping them into Markdown. We only have to do anything special with them if we want to structure the data they contain, and it's not obvious to me that doing that adds a lot of value. Even if it is worth it, we can defer that extra "deep structure" until we want it.

But we (I) forgot to remove the ingredient from the recipe, so that's what this PR does.

