### PR TITLE
Add data.interactive example handler

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -4,14 +4,6 @@ const visit = require("unist-util-visit");
 const utils = require("./utils.js");
 
 /**
- * Function returning true only if the given node is a text node
- * that contains only newlines.
- */
-function isNewlineOnlyTextNode(node) {
-  return node.type === "text" && node.value.match(/^\n*$/);
-}
-
-/**
  * Checks a single example. This only does any checking for live samples:
  * that is, examples that contain a call to the EmbedLiveSample macro.
  */
@@ -21,7 +13,7 @@ function checkExample(exampleNodes, logger) {
     // If we have already seen an EmbedLiveSample call...
     if (liveSampleNode !== null) {
       // ...then the only nodes allowed after that point are text nodes containing only newlines
-      if (!isNewlineOnlyTextNode(node)) {
+      if (!utils.isNewlineOnlyTextNode(node)) {
         logger.fail(
           node,
           "EmbedLiveSample must be final node",

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
@@ -4,77 +4,106 @@ const visit = require("unist-util-visit");
 const utils = require("./utils.js");
 
 /**
- * Counts and returns the number of calls to EmbedInteractiveExample
- * in the given `tree`
+ * Return all the interactive examples in the given tree.
  */
-function countInteractiveExamples(tree) {
-  let macroCount = 0;
+function getInteractiveExamples(tree) {
+  let nodes = [];
   visit(
     tree,
     (node) => utils.isMacro(node, "EmbedInteractiveExample"),
-    () => {
-      macroCount += 1;
+    (node, index, parent) => {
+      nodes.push(parent);
     }
   );
 
-  return macroCount;
+  return nodes;
 }
 
 /**
- * The interactive example must be inside a DIV and must be found
- * before the first H2 in the document.
+ * Interactive examples are calls to the EmbedInteractiveExample macro,
+ * placed directly inside a DIV.
  */
-function validateExample(body, logger) {
-  let interactiveExampleExists = false;
-  // fetch the section of the document before the first H2
-  const beforeH2 = utils.sliceSection(body.children[0], body);
-  // check that section for interactive examples
-  visit(
-    beforeH2,
-    (node) => utils.isMacro(node, "EmbedInteractiveExample"),
-    (node, index, parent) => {
-      interactiveExampleExists = true;
-      if (parent.tagName !== "div") {
-        logger.fail(
-          beforeH2,
-          "Interactive example must be in a DIV",
-          "interactive-example-in-div"
-        );
-      }
-      return visit.EXIT;
-    }
+function isInteractiveExampleNode(node) {
+  return (
+    node.tagName === "div" &&
+    node.children.length === 1 &&
+    utils.isMacro(node.children[0], "EmbedInteractiveExample")
   );
-  if (!interactiveExampleExists) {
-    logger.fail(
-      beforeH2,
-      "Interactive example must be before first H2",
-      "interactive-example-before-first-h2"
-    );
-  }
+}
+
+/**
+ * Test whether the given node is a paragraph and not an admonition.
+ */
+function isParagraph(node) {
+  return node && node.tagName === "p" && !utils.isAdmonition(node);
 }
 
 /**
  * Handler for the `data.interactive_example?` ingredient.
  */
 function handleDataInteractiveExample(tree, logger) {
-  const body = select(`body`, tree);
-  // count the number of interactive examples
-  const interactiveExampleCount = countInteractiveExamples(body);
-  switch (interactiveExampleCount) {
-    case 0:
-      // this ingredient is optional, so if there are no examples, we pass
-      return;
-    case 1:
-      // one example was found: validate it
-      validateExample(body, logger);
-      break;
-    default:
-      // more than one example is an error
+  const body = select("body", tree);
+
+  // check the part of the doc from the first H2 onwards
+  // it must contain zero interactive examples
+  const firstH2 = select("h2", body);
+  if (firstH2) {
+    const afterFirstH2 = utils.sliceBetween(firstH2, () => false, body);
+    const interactiveExamples = getInteractiveExamples(afterFirstH2);
+    if (interactiveExamples.length > 0) {
       logger.fail(
-        body,
-        "Must contain at most one interactive example",
-        "at-most-one-interactive-example"
+        afterFirstH2,
+        "Interactive examples must be before first H2",
+        "interactive-example-before-first-h2"
       );
+    }
+  }
+
+  // check the part of the doc from the first H2 onwards
+  // it must contain zero or one interactive examples
+  const beforeFirstH2 = utils.sliceSection(body.children[0], body);
+  const interactiveExamples = getInteractiveExamples(beforeFirstH2);
+  if (interactiveExamples.length > 1) {
+    logger.fail(
+      beforeFirstH2,
+      "Only one interactive example may be included",
+      "at-most-one-interactive-example"
+    );
+  }
+  // if the part of the doc from the first H2 onwards contains
+  // zero interactive examples, we have no more checks
+  if (interactiveExamples.length === 0) {
+    return;
+  }
+  // if the part of the doc from the first H2 onwards contains
+  // one interactive example, it must be a DIV
+  if (interactiveExamples[0].tagName !== "div") {
+    logger.fail(
+      interactiveExamples[0],
+      "Interactive example must be in a DIV",
+      "interactive-example-inside-div"
+    );
+  }
+
+  // finally check where it is in the "beforeFirstH2" section
+  // it must be at the top level, after a P that's not an admonition
+
+  // first, though, we don't care about newline-only text nodes
+  const nodes = beforeFirstH2.children.filter(
+    (node) => !utils.isNewlineOnlyTextNode(node)
+  );
+  let previous = null;
+  for (const node of nodes) {
+    if (isInteractiveExampleNode(node)) {
+      if (!isParagraph(previous)) {
+        logger.fail(
+          node,
+          "Interactive example must be preceded by a P node",
+          "interactive-example-preceded-by-p"
+        );
+      }
+    }
+    previous = node;
   }
 }
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
@@ -1,0 +1,81 @@
+const { select } = require("hast-util-select");
+const visit = require("unist-util-visit");
+
+const utils = require("./utils.js");
+
+/**
+ * Counts and returns the number of calls to EmbedInteractiveExample
+ * in the given `tree`
+ */
+function countInteractiveExamples(tree) {
+  let macroCount = 0;
+  visit(
+    tree,
+    (node) => utils.isMacro(node, "EmbedInteractiveExample"),
+    () => {
+      macroCount += 1;
+    }
+  );
+
+  return macroCount;
+}
+
+/**
+ * The interactive example must be inside a DIV and must be found
+ * before the first H2 in the document.
+ */
+function validateExample(body, logger) {
+  let interactiveExampleExists = false;
+  // fetch the section of the document before the first H2
+  const beforeH2 = utils.sliceSection(body.children[0], body);
+  // check that section for interactive examples
+  visit(
+    beforeH2,
+    (node) => utils.isMacro(node, "EmbedInteractiveExample"),
+    (node, index, parent) => {
+      interactiveExampleExists = true;
+      if (parent.tagName !== "div") {
+        logger.fail(
+          beforeH2,
+          "Interactive example must be in a DIV",
+          "interactive-example-in-div"
+        );
+      }
+      return visit.EXIT;
+    }
+  );
+  if (!interactiveExampleExists) {
+    logger.fail(
+      beforeH2,
+      "Interactive example must be before first H2",
+      "interactive-example-before-first-h2"
+    );
+  }
+}
+
+/**
+ * Handler for the `data.interactive_example?` ingredient.
+ */
+function handleDataInteractiveExample(tree, logger) {
+  const body = select(`body`, tree);
+  // count the number of interactive examples
+  const interactiveExampleCount = countInteractiveExamples(body);
+  switch (interactiveExampleCount) {
+    case 0:
+      // this ingredient is optional, so if there are no examples, we pass
+      return;
+    case 1:
+      // one example was found: validate it
+      validateExample(body, logger);
+      break;
+    default:
+      // more than one example is an error
+      logger.fail(
+        body,
+        "Must contain at most one interactive example",
+        "at-most-one-interactive-example"
+      );
+  }
+}
+
+module.exports = handleDataInteractiveExample;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
@@ -4,24 +4,8 @@ const visit = require("unist-util-visit");
 const utils = require("./utils.js");
 
 /**
- * Return all the interactive examples in the given tree.
- */
-function getInteractiveExamples(tree) {
-  let nodes = [];
-  visit(
-    tree,
-    (node) => utils.isMacro(node, "EmbedInteractiveExample"),
-    (node, index, parent) => {
-      nodes.push(parent);
-    }
-  );
-
-  return nodes;
-}
-
-/**
- * Interactive examples are calls to the EmbedInteractiveExample macro,
- * placed directly inside a DIV.
+ * Tests whether the given node is a DIV containing only
+ * a call to the EmbedInteractiveExample macro.
  */
 function isInteractiveExampleNode(node) {
   return (
@@ -32,7 +16,7 @@ function isInteractiveExampleNode(node) {
 }
 
 /**
- * Function returning true only if the given node is a P node
+ * Tests whether the given node is a P node
  * that isn't a warning or a note.
  */
 function isAdmonition(node) {
@@ -45,7 +29,7 @@ function isAdmonition(node) {
 }
 
 /**
- * Test whether the given node is a paragraph and not an admonition.
+ * Tests whether the given node is a paragraph and not an admonition.
  */
 function isParagraph(node) {
   return node && node.tagName === "p" && !isAdmonition(node);
@@ -63,39 +47,53 @@ function handleDataInteractiveExample(tree, logger) {
   const firstH2 = select("h2", body);
   if (firstH2) {
     const afterFirstH2 = utils.sliceBetween(firstH2, () => false, body);
-    const interactiveExamples = getInteractiveExamples(afterFirstH2);
-    if (interactiveExamples.length > 0) {
-      logger.fail(
-        afterFirstH2,
-        "Interactive examples must be before first H2",
-        "interactive-example-before-first-h2"
-      );
-      ok = false;
-    }
+    visit(
+      afterFirstH2,
+      (node) => utils.isMacro(node, "EmbedInteractiveExample"),
+      (node) => {
+        logger.fail(
+          node,
+          "Interactive examples are not allowed after first H2",
+          "interactive-example-after-first-h2"
+        );
+        ok = false;
+      }
+    );
   }
 
   // check the part of the doc up to the first H2
   // it must contain zero or one interactive examples
   const beforeFirstH2 = utils.sliceSection(body.children[0], body);
-  const interactiveExamples = getInteractiveExamples(beforeFirstH2);
-  if (interactiveExamples.length > 1) {
-    logger.fail(
-      beforeFirstH2,
-      "Only one interactive example may be included",
-      "at-most-one-interactive-example"
-    );
-    ok = false;
-  }
+  let interactiveExampleParent = null;
+  visit(
+    beforeFirstH2,
+    (node) => utils.isMacro(node, "EmbedInteractiveExample"),
+    (node, index, parent) => {
+      // if we have already seen an interactive example, seeing another one is an error
+      if (interactiveExampleParent) {
+        logger.fail(
+          node,
+          "Only one interactive example is allowed",
+          "at-most-one-interactive-example"
+        );
+        ok = false;
+      } else {
+        interactiveExampleParent = parent;
+      }
+    }
+  );
+
   // if the part of the doc up to the first H2 contains
   // zero interactive examples, we have no more checks
-  if (interactiveExamples.length === 0) {
+  if (interactiveExampleParent === null) {
     return null;
   }
+
   // if the part of the doc up to the first H2 contains
   // one interactive example, it must be a DIV
-  if (interactiveExamples[0].tagName !== "div") {
+  if (interactiveExampleParent.tagName !== "div") {
     logger.fail(
-      interactiveExamples[0],
+      interactiveExampleParent,
       "Interactive example must be in a DIV",
       "interactive-example-inside-div"
     );
@@ -125,7 +123,7 @@ function handleDataInteractiveExample(tree, logger) {
   }
 
   if (ok) {
-    return interactiveExamples[0];
+    return interactiveExampleParent;
   } else {
     return null;
   }

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
@@ -59,7 +59,7 @@ function handleDataInteractiveExample(tree, logger) {
     }
   }
 
-  // check the part of the doc from the first H2 onwards
+  // check the part of the doc up to the first H2
   // it must contain zero or one interactive examples
   const beforeFirstH2 = utils.sliceSection(body.children[0], body);
   const interactiveExamples = getInteractiveExamples(beforeFirstH2);
@@ -70,12 +70,12 @@ function handleDataInteractiveExample(tree, logger) {
       "at-most-one-interactive-example"
     );
   }
-  // if the part of the doc from the first H2 onwards contains
+  // if the part of the doc up to the first H2 contains
   // zero interactive examples, we have no more checks
   if (interactiveExamples.length === 0) {
     return;
   }
-  // if the part of the doc from the first H2 onwards contains
+  // if the part of the doc up to the first H2 contains
   // one interactive example, it must be a DIV
   if (interactiveExamples[0].tagName !== "div") {
     logger.fail(

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-interactive-example.js
@@ -32,16 +32,30 @@ function isInteractiveExampleNode(node) {
 }
 
 /**
+ * Function returning true only if the given node is a P node
+ * that isn't a warning or a note.
+ */
+function isAdmonition(node) {
+  return (
+    node.tagName === "p" &&
+    node.properties.className &&
+    (node.properties.className.includes("warning") ||
+      node.properties.className.includes("note"))
+  );
+}
+
+/**
  * Test whether the given node is a paragraph and not an admonition.
  */
 function isParagraph(node) {
-  return node && node.tagName === "p" && !utils.isAdmonition(node);
+  return node && node.tagName === "p" && !isAdmonition(node);
 }
 
 /**
  * Handler for the `data.interactive_example?` ingredient.
  */
 function handleDataInteractiveExample(tree, logger) {
+  let ok = true;
   const body = select("body", tree);
 
   // check the part of the doc from the first H2 onwards
@@ -56,6 +70,7 @@ function handleDataInteractiveExample(tree, logger) {
         "Interactive examples must be before first H2",
         "interactive-example-before-first-h2"
       );
+      ok = false;
     }
   }
 
@@ -69,11 +84,12 @@ function handleDataInteractiveExample(tree, logger) {
       "Only one interactive example may be included",
       "at-most-one-interactive-example"
     );
+    ok = false;
   }
   // if the part of the doc up to the first H2 contains
   // zero interactive examples, we have no more checks
   if (interactiveExamples.length === 0) {
-    return;
+    return null;
   }
   // if the part of the doc up to the first H2 contains
   // one interactive example, it must be a DIV
@@ -83,6 +99,7 @@ function handleDataInteractiveExample(tree, logger) {
       "Interactive example must be in a DIV",
       "interactive-example-inside-div"
     );
+    ok = false;
   }
 
   // finally check where it is in the "beforeFirstH2" section
@@ -101,9 +118,16 @@ function handleDataInteractiveExample(tree, logger) {
           "Interactive example must be preceded by a P node",
           "interactive-example-preceded-by-p"
         );
+        ok = false;
       }
     }
     previous = node;
+  }
+
+  if (ok) {
+    return interactiveExamples[0];
+  } else {
+    return null;
   }
 }
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -24,10 +24,15 @@ const classMembers = require("./data-class-members");
  *
  */
 const ingredientHandlers = {
-  "data.interactive_example?": handleDataInteractiveExample,
   "data.browser_compatibility": handleDataBrowserCompatibility,
+  "data.constructor_properties?": classMembers.handleDataConstructorProperties,
   "data.examples": handleDataExamples,
+  "data.instance_methods?": classMembers.handleDataInstanceMethods,
+  "data.instance_properties?": classMembers.handleDataInstanceProperties,
+  "data.interactive_example?": handleDataInteractiveExample,
   "data.specifications": handleDataSpecifications,
+  "data.static_methods?": classMembers.handleDataStaticMethods,
+  "data.static_properties?": classMembers.handleDataStaticProperties,
   "prose.description": requireTopLevelHeading("Description"),
   "prose.error_type": requireTopLevelHeading("Error_type"),
   "prose.message": requireTopLevelHeading("Message"),
@@ -35,11 +40,6 @@ const ingredientHandlers = {
   "prose.short_description": handleProseShortDescription,
   "prose.syntax": requireTopLevelHeading("Syntax"),
   "prose.what_went_wrong": requireTopLevelHeading("What_went_wrong"),
-  "data.constructor_properties?": classMembers.handleDataConstructorProperties,
-  "data.static_methods?": classMembers.handleDataStaticMethods,
-  "data.static_properties?": classMembers.handleDataStaticProperties,
-  "data.instance_methods?": classMembers.handleDataInstanceMethods,
-  "data.instance_properties?": classMembers.handleDataInstanceProperties,
 };
 
 /**

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -2,6 +2,7 @@ const { select } = require("hast-util-select");
 
 const handleDataSpecifications = require("./data-specifications");
 const handleDataExamples = require("./data-examples");
+const handleDataInteractiveExample = require("./data-interactive-example");
 const handleDataBrowserCompatibility = require("./data-browser-compatibility");
 const handleProseShortDescription = require("./prose-short-description");
 const classMembers = require("./data-class-members");
@@ -23,6 +24,7 @@ const classMembers = require("./data-class-members");
  *
  */
 const ingredientHandlers = {
+  "data.interactive_example?": handleDataInteractiveExample,
   "data.browser_compatibility": handleDataBrowserCompatibility,
   "data.examples": handleDataExamples,
   "data.specifications": handleDataSpecifications,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-short-description.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-short-description.js
@@ -52,12 +52,7 @@ function handleProseShortDescription(tree, logger) {
   );
 
   // Remove admonition paragraphs
-  const isAdmonition = (node) =>
-    node.tagName === "p" &&
-    node.properties.className &&
-    (node.properties.className.includes("warning") ||
-      node.properties.className.includes("note"));
-  const filtered = filter(introSection, (node) => !isAdmonition(node));
+  const filtered = filter(introSection, (node) => !utils.isAdmonition(node));
 
   // Get the first paragraph left over
   const shortDescriptionP = select("p", filtered);

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
@@ -79,19 +79,6 @@ function isNewlineOnlyTextNode(node) {
   return node.type === "text" && node.value.match(/^\n*$/);
 }
 
-/**
- * Function returning true only if the given node is a P node
- * that isn't a warning or a note.
- */
-function isAdmonition(node) {
-  return (
-    node.tagName === "p" &&
-    node.properties.className &&
-    (node.properties.className.includes("warning") ||
-      node.properties.className.includes("note"))
-  );
-}
-
 function Logger(file, source, recipeName, ingredient) {
   return {
     expected: function (node, name, id) {
@@ -114,6 +101,5 @@ module.exports = {
   sliceBetween,
   isMacro,
   isNewlineOnlyTextNode,
-  isAdmonition,
   Logger,
 };

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
@@ -71,6 +71,23 @@ function isMacro(node, macroName) {
   );
 }
 
+/**
+ * Function returning true only if the given node is a text node
+ * that contains only newlines.
+ */
+function isNewlineOnlyTextNode(node) {
+  return node.type === "text" && node.value.match(/^\n*$/);
+}
+
+function isAdmonition(node) {
+  return (
+    node.tagName === "p" &&
+    node.properties.className &&
+    (node.properties.className.includes("warning") ||
+      node.properties.className.includes("note"))
+  );
+}
+
 function Logger(file, source, recipeName, ingredient) {
   return {
     expected: function (node, name, id) {
@@ -92,5 +109,7 @@ module.exports = {
   sliceSection,
   sliceBetween,
   isMacro,
+  isNewlineOnlyTextNode,
+  isAdmonition,
   Logger,
 };

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
@@ -79,6 +79,10 @@ function isNewlineOnlyTextNode(node) {
   return node.type === "text" && node.value.match(/^\n*$/);
 }
 
+/**
+ * Function returning true only if the given node is a P node
+ * that isn't a warning or a note.
+ */
 function isAdmonition(node) {
   return (
     node.tagName === "p" &&

--- a/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
@@ -1,0 +1,76 @@
+const { process } = require("./framework/utils");
+
+const sources = {
+  no_interactive_examples: `<p>An intro</p>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>`,
+
+  two_interactive_examples: `<p>An intro</p>
+<div>{{EmbedInteractiveExample()}}</div>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>
+<div>{{EmbedInteractiveExample()}}</div>`,
+
+  interactive_example_after_h2: `<p>An intro</p>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>
+<div>{{EmbedInteractiveExample()}}</div>`,
+
+  interactive_example_not_in_div: `<p>An intro</p>
+<p>{{EmbedInteractiveExample()}}</p>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>`,
+
+  valid_interactive_example: `<p>An intro</p>
+<div>{{EmbedInteractiveExample()}}</div>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>`,
+};
+
+describe("data.examples", () => {
+  const testRecipe = { body: ["data.interactive_example?"] };
+
+  test("no interactive examples", () => {
+    const file = process(sources.no_interactive_examples, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId("/unknown-heading");
+  });
+
+  test("two interactive examples", () => {
+    const file = process(sources.two_interactive_examples, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).hasMessageWithId(
+      "data.interactive_example?/at-most-one-interactive-example"
+    );
+  });
+
+  test("interactive example after H2", () => {
+    const file = process(sources.interactive_example_after_h2, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).hasMessageWithId(
+      "data.interactive_example?/interactive-example-before-first-h2"
+    );
+  });
+
+  test("interactive example not in DIV", () => {
+    const file = process(sources.interactive_example_not_in_div, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).hasMessageWithId(
+      "data.interactive_example?/interactive-example-in-div"
+    );
+  });
+
+  test("valid interactive example", () => {
+    const file = process(sources.valid_interactive_example, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId("/unknown-heading");
+  });
+});

--- a/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
@@ -7,9 +7,10 @@ const sources = {
 
   two_interactive_examples: `<p>An intro</p>
 <div>{{EmbedInteractiveExample()}}</div>
-<h2 id="A_heading">A heading</h2>
 <p>Some more stuff</p>
-<div>{{EmbedInteractiveExample()}}</div>`,
+<div>{{EmbedInteractiveExample()}}</div>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>`,
 
   interactive_example_after_h2: `<p>An intro</p>
 <h2 id="A_heading">A heading</h2>
@@ -18,6 +19,11 @@ const sources = {
 
   interactive_example_not_in_div: `<p>An intro</p>
 <p>{{EmbedInteractiveExample()}}</p>
+<h2 id="A_heading">A heading</h2>
+<p>Some more stuff</p>`,
+
+  interactive_example_not_after_p: `<div>An intro</div>
+<div>{{EmbedInteractiveExample()}}</div>
 <h2 id="A_heading">A heading</h2>
 <p>Some more stuff</p>`,
 
@@ -63,7 +69,17 @@ describe("data.examples", () => {
     expect(file.messages.length).toBe(2);
     expect(file).hasMessageWithId("/unknown-heading");
     expect(file).hasMessageWithId(
-      "data.interactive_example?/interactive-example-in-div"
+      "data.interactive_example?/interactive-example-inside-div"
+    );
+  });
+
+  test("interactive example not after P", () => {
+    const file = process(sources.interactive_example_not_after_p, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).hasMessageWithId(
+      "data.interactive_example?/interactive-example-preceded-by-p"
     );
   });
 

--- a/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.interactive_example.test.js
@@ -33,21 +33,25 @@ const sources = {
 <p>Some more stuff</p>`,
 };
 
-describe("data.examples", () => {
+describe("data.interactive_example?", () => {
   const testRecipe = { body: ["data.interactive_example?"] };
 
   test("no interactive examples", () => {
     const file = process(sources.no_interactive_examples, testRecipe);
 
     expect(file.messages.length).toBe(1);
-    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).not.hasMessageWithId("data.interactive_example?");
   });
 
   test("two interactive examples", () => {
     const file = process(sources.two_interactive_examples, testRecipe);
 
     expect(file.messages.length).toBe(2);
-    expect(file).hasMessageWithId("/unknown-heading");
+    // expect that it doesn't have any messages with ID "data.interactive_example?"
+    // unless they are followed by "/at-most-one-interactive-example"
+    expect(file).not.hasMessageWithId(
+      /data\.interactive_example\?(?!\/at-most-one-interactive-example)/
+    );
     expect(file).hasMessageWithId(
       "data.interactive_example?/at-most-one-interactive-example"
     );
@@ -57,9 +61,13 @@ describe("data.examples", () => {
     const file = process(sources.interactive_example_after_h2, testRecipe);
 
     expect(file.messages.length).toBe(2);
-    expect(file).hasMessageWithId("/unknown-heading");
+    // expect that it doesn't have any messages with ID containing "data.interactive_example?"
+    // unless it is followed by "/interactive-example-after-first-h2"
+    expect(file).not.hasMessageWithId(
+      /data\.interactive_example\?(?!\/interactive-example-after-first-h2)/
+    );
     expect(file).hasMessageWithId(
-      "data.interactive_example?/interactive-example-before-first-h2"
+      "data.interactive_example?/interactive-example-after-first-h2"
     );
   });
 
@@ -67,7 +75,11 @@ describe("data.examples", () => {
     const file = process(sources.interactive_example_not_in_div, testRecipe);
 
     expect(file.messages.length).toBe(2);
-    expect(file).hasMessageWithId("/unknown-heading");
+    // expect that it doesn't have any messages with ID containing "data.interactive_example?"
+    // unless it is followed by "/interactive-example-inside-div"
+    expect(file).not.hasMessageWithId(
+      /data\.interactive_example\?(?!\/interactive-example-inside-div)/
+    );
     expect(file).hasMessageWithId(
       "data.interactive_example?/interactive-example-inside-div"
     );
@@ -77,7 +89,11 @@ describe("data.examples", () => {
     const file = process(sources.interactive_example_not_after_p, testRecipe);
 
     expect(file.messages.length).toBe(2);
-    expect(file).hasMessageWithId("/unknown-heading");
+    // expect that it doesn't have any messages with ID containing "data.interactive_example?"
+    // unless it is followed by "/interactive-example-preceded-by-p"
+    expect(file).not.hasMessageWithId(
+      /data\.interactive_example\?(?!\/interactive-example-preceded-by-p)/
+    );
     expect(file).hasMessageWithId(
       "data.interactive_example?/interactive-example-preceded-by-p"
     );
@@ -87,6 +103,6 @@ describe("data.examples", () => {
     const file = process(sources.valid_interactive_example, testRecipe);
 
     expect(file.messages.length).toBe(1);
-    expect(file).hasMessageWithId("/unknown-heading");
+    expect(file).not.hasMessageWithId("data.interactive_example?");
   });
 });


### PR DESCRIPTION
This PR lints `data.interactive example?` according to the specification: https://github.com/mdn/stumptown-content/blob/master/project-docs/javascript-linter-spec.md#datainteractive_example, as requested in https://github.com/mdn/stumptown-content/issues/408.

I wanted to use a couple of functions that were in other handlers: `isNewlineOnlyTextNode` and `isAdmonition`, so moved them into utils.