### PR TITLE
Accept jsxref as dt element contents inside link lists

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
@@ -2,6 +2,21 @@ const select = require("hast-util-select");
 
 const utils = require("./utils.js");
 
+/**
+ * Returns true only if the given node contains a single child,
+ * andthe child is either an A element or a call to the jsxref macro.
+ */
+function containsLinkOrXRef(node) {
+  if (node.children.length === 1) {
+    if (node.children[0].tagName === "a") {
+      return true;
+    } else if (utils.isMacro(node.children[0], "jsxref")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function checkLinkList(id, tree, logger) {
   const body = select.select("body", tree);
 
@@ -55,17 +70,13 @@ function checkLinkList(id, tree, logger) {
     return;
   }
 
-  // Each <dt> must contain only a single <a> element
+  // Each <dt> must contain only a single <a> element or a call to jsxref.
   for (const dt of dts) {
-    if (
-      dt.children.length !== 1 ||
-      dt.children[0].type !== "element" ||
-      dt.children[0].tagName !== "a"
-    ) {
+    if (!containsLinkOrXRef(dt)) {
       logger.fail(
         dt,
-        "dt elements in link lists must contain a single anchor element",
-        "only-single-anchor-element-in-link-list-dt"
+        "dt elements in link lists must contain a single anchor element or xref macro call",
+        "only-single-anchor-element-or-xref-in-link-list-dt"
       );
     }
   }

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
@@ -4,7 +4,7 @@ const utils = require("./utils.js");
 
 /**
  * Returns true only if the given node contains a single child,
- * andthe child is either an A element or a call to the jsxref macro.
+ * and the child is either an A element or a call to the jsxref macro.
  */
 function containsLinkOrXRef(node) {
   if (node.children.length === 1) {

--- a/scripts/scraper-ng/test/ingredient-data.static_methods.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.static_methods.test.js
@@ -1,0 +1,149 @@
+const { process } = require("./framework/utils");
+
+const sources = {
+  no_static_methods: `<p>Some content.</p>
+<p>Some more content.</p>`,
+
+  valid_static_methods_with_a: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl>
+  <dt><a><code>A link</code></a></dt>
+  <dd>A description</dd>
+  <dt><a><code>Another link</code></a></dt>
+  <dd>A description</dd>
+</dl>`,
+
+  valid_static_methods_with_xref: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl>
+  <dt>{{jsxref}}</dt>
+  <dd>A description</dd>
+</dl>`,
+
+  invalid_static_methods_empty_heading: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>`,
+
+  invalid_static_methods_empty_dl: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl></dl>`,
+
+  invalid_static_methods_heading_with_non_dl: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<p>Not a dl</p>
+<dl></dl>`,
+
+  invalid_static_methods_heading_with_multiple_dl: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl>
+  <dt><a><code>A link</code></a></dt>
+  <dd>A description</dd>
+</dl>
+<dl>
+  <dt><a><code>A link</code></a></dt>
+  <dd>A description</dd>
+</dl>`,
+
+  invalid_static_methods_no_valid_dt: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl>
+  <dt><p>A link</p></dt>
+  <dd>A description</dd>
+</dl>`,
+
+  invalid_static_methods_unordered_dl: `<p>Some content.</p>
+<h2 id="Static_methods">Static methods</h2>
+<dl>
+  <dt><a><code>Another link</code></a></dt>
+  <dd>A description</dd>
+  <dt><a><code>A link</code></a></dt>
+  <dd>A description</dd>
+</dl>`,
+};
+
+describe("data.static_methods", () => {
+  const testRecipe = { body: ["data.static_methods?"] };
+
+  test("no static methods", () => {
+    const file = process(sources.no_static_methods, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+  });
+
+  test("valid static methods with A elements", () => {
+    const file = process(sources.valid_static_methods_with_a, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+  });
+
+  test("valid static methods with jsxref", () => {
+    const file = process(sources.valid_static_methods_with_xref, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file.messages[0].ruleId).toEqual("jsxref");
+  });
+
+  test("invalid static methods with empty heading", () => {
+    const file = process(
+      sources.invalid_static_methods_empty_heading,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.static_methods?/only-single-dl-element-in-link-list"
+    );
+  });
+
+  test("invalid static methods with empty dl", () => {
+    const file = process(sources.invalid_static_methods_empty_dl, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId("data.static_methods?/dl-must-contain-dt");
+  });
+
+  test("invalid static methods with extra non-dl", () => {
+    const file = process(
+      sources.invalid_static_methods_heading_with_non_dl,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.static_methods?/only-single-dl-element-in-link-list"
+    );
+  });
+
+  test("invalid static methods with multiple dl", () => {
+    const file = process(
+      sources.invalid_static_methods_heading_with_multiple_dl,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.static_methods?/only-single-dl-element-in-link-list"
+    );
+  });
+
+  test("invalid static methods with invalid dt", () => {
+    const file = process(
+      sources.invalid_static_methods_no_valid_dt,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.static_methods?/only-single-anchor-element-or-xref-in-link-list-dt"
+    );
+  });
+
+  test("invalid static methods with unordered dl", () => {
+    const file = process(
+      sources.invalid_static_methods_unordered_dl,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId("data.static_methods?/link-list-alpha-order");
+  });
+});


### PR DESCRIPTION
See https://github.com/mdn/stumptown-content/issues/407.

This fixes the linter errors by tolerating `{{jsxref}}` in `dt` elements in link lists.

I'm still not certain that this is preferable to rendering them out, but what tipped me into doing this is that our spec says we should accept `{{jsxref}}`: https://github.com/mdn/stumptown-content/blob/master/project-docs/javascript-linter-spec.md#dataconstructor_properties.

Since this didn't have any tests I also added some.