### PR TITLE
Add handler for the data.constructor ingredient

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -69,7 +69,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkTag(dd.children[1], "a")) {
     logger.fail(
       section,
-      "Constructor description second node is incorrect",
+      "Constructor description must contain a link after `Creates a new`",
       "constructor-description-second-node"
     );
     ok = false;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -60,7 +60,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkText(dd.children[0], "Creates a new ")) {
     logger.fail(
       section,
-      "Constructor description first node is incorrect",
+      "Constructor description must be in the form `Creates a new <a>...</a> object.`",
       "constructor-description-first-node"
     );
     ok = false;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -51,7 +51,7 @@ function handleDataConstructor(tree, logger) {
   if (dd.children.length !== 3) {
     logger.fail(
       section,
-      "Constructor description must contain three nodes",
+      "Constructor description must be in the form `Creates a new <a>...</a> object.`",
       "constructor-description-three-nodes"
     );
     return null;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -1,0 +1,84 @@
+const select = require("hast-util-select");
+
+const utils = require("./utils.js");
+const checkLinkList = require("./link-list-checker.js");
+
+function checkText(node, text) {
+  return node.type === "text" && node.value === text;
+}
+
+function checkTag(node, tag) {
+  return node.type === "element" && node.tagName === tag;
+}
+
+/**
+ * Handler for the `data.constructor` ingredient.
+ */
+function handleDataConstructor(tree, logger) {
+  // Check common link list structure
+  checkLinkList("Constructor", tree, logger);
+
+  // Constructor is a mandatory property
+  const heading = select.select(`h2#Constructor`, tree);
+  if (heading === null) {
+    logger.expected(tree, `h2#Constructor`, "expected-heading");
+    return;
+  }
+
+  // This link list is only allowed one entry
+  const section = utils.sliceSection(heading, tree);
+  const dts = select.selectAll("dt", section);
+  if (dts.length !== 1) {
+    logger.fail(
+      section,
+      "Constructor section may only contain one DT item",
+      "only-single-constructor-dt"
+    );
+  }
+  const dds = select.selectAll("dd", section);
+  if (dds.length !== 1) {
+    logger.fail(
+      section,
+      "Constructor section may only contain one DD item",
+      "only-single-constructor-dd"
+    );
+    return;
+  }
+
+  // The dd must be of the form: "Creates a new <a>...</a> object."
+  const dd = dds[0];
+  if (dd.children.length !== 3) {
+    logger.fail(
+      section,
+      "Constructor description must contain three nodes",
+      "constructor-description-three-nodes"
+    );
+    return;
+  }
+
+  if (!checkText(dd.children[0], "Creates a new ")) {
+    logger.fail(
+      section,
+      "Constructor description first node is incorrect",
+      "constructor-description-first-node"
+    );
+  }
+
+  if (!checkTag(dd.children[1], "a")) {
+    logger.fail(
+      section,
+      "Constructor description second node is incorrect",
+      "constructor-description-second-node"
+    );
+  }
+
+  if (!checkText(dd.children[2], " object.")) {
+    logger.fail(
+      section,
+      "Constructor description third node is incorrect",
+      "constructor-description-third-node"
+    );
+  }
+}
+
+module.exports = handleDataConstructor;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -50,7 +50,7 @@ function handleDataConstructor(tree, logger) {
   const dd = dds[0];
   if (dd.children.length !== 3) {
     logger.fail(
-      section,
+      dd,
       "Constructor description must be in the form `Creates a new <a>...</a> object.`",
       "constructor-description-three-nodes"
     );

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -15,15 +15,15 @@ function checkTag(node, tag) {
  * Handler for the `data.constructor` ingredient.
  */
 function handleDataConstructor(tree, logger) {
-  // Check common link list structure
-  checkLinkList("Constructor", tree, logger);
-
   // Constructor is a mandatory property
   const heading = select.select(`h2#Constructor`, tree);
   if (heading === null) {
     logger.expected(tree, `h2#Constructor`, "expected-heading");
-    return;
+    return null;
   }
+
+  // Check common link list structure
+  let ok = checkLinkList("Constructor", tree, logger);
 
   // This link list is only allowed one entry
   const section = utils.sliceSection(heading, tree);
@@ -34,6 +34,7 @@ function handleDataConstructor(tree, logger) {
       "Constructor section may only contain one DT item",
       "only-single-constructor-dt"
     );
+    ok = false;
   }
   const dds = select.selectAll("dd", section);
   if (dds.length !== 1) {
@@ -42,7 +43,7 @@ function handleDataConstructor(tree, logger) {
       "Constructor section may only contain one DD item",
       "only-single-constructor-dd"
     );
-    return;
+    return null;
   }
 
   // The dd must be of the form: "Creates a new <a>...</a> object."
@@ -53,7 +54,7 @@ function handleDataConstructor(tree, logger) {
       "Constructor description must contain three nodes",
       "constructor-description-three-nodes"
     );
-    return;
+    return null;
   }
 
   if (!checkText(dd.children[0], "Creates a new ")) {
@@ -62,6 +63,7 @@ function handleDataConstructor(tree, logger) {
       "Constructor description first node is incorrect",
       "constructor-description-first-node"
     );
+    ok = false;
   }
 
   if (!checkTag(dd.children[1], "a")) {
@@ -70,6 +72,7 @@ function handleDataConstructor(tree, logger) {
       "Constructor description second node is incorrect",
       "constructor-description-second-node"
     );
+    ok = false;
   }
 
   if (!checkText(dd.children[2], " object.")) {
@@ -78,6 +81,13 @@ function handleDataConstructor(tree, logger) {
       "Constructor description third node is incorrect",
       "constructor-description-third-node"
     );
+    ok = false;
+  }
+
+  if (ok) {
+    return heading;
+  } else {
+    return null;
   }
 }
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -60,7 +60,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkText(dd.children[0], "Creates a new ")) {
     logger.fail(
       section,
-      "Constructor description must be in the form `Creates a new <a>...</a> object.`",
+      "Constructor description must be in the form 'Creates a new <a>...</a> object.'",
       "constructor-description-first-node"
     );
     ok = false;
@@ -69,7 +69,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkTag(dd.children[1], "a")) {
     logger.fail(
       section,
-      "Constructor description must contain a link after `Creates a new`",
+      "Constructor description must contain a link after 'Creates a new'",
       "constructor-description-second-node"
     );
     ok = false;
@@ -78,7 +78,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkText(dd.children[2], " object.")) {
     logger.fail(
       section,
-      "Constructor description must end with " object.",
+      "Constructor description must end with ' object.'",
       "constructor-description-third-node"
     );
     ok = false;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -78,7 +78,7 @@ function handleDataConstructor(tree, logger) {
   if (!checkText(dd.children[2], " object.")) {
     logger.fail(
       section,
-      "Constructor description third node is incorrect",
+      "Constructor description must end with " object.",
       "constructor-description-third-node"
     );
     ok = false;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -4,6 +4,7 @@ const handleDataSpecifications = require("./data-specifications");
 const handleDataExamples = require("./data-examples");
 const handleDataBrowserCompatibility = require("./data-browser-compatibility");
 const handleProseShortDescription = require("./prose-short-description");
+const handleDataConstructor = require("./data-constructor");
 const classMembers = require("./data-class-members");
 
 /**
@@ -34,6 +35,7 @@ const ingredientHandlers = {
   "prose.syntax": requireTopLevelHeading("Syntax"),
   "prose.what_went_wrong": requireTopLevelHeading("What_went_wrong"),
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
+  "data.constructor": handleDataConstructor,
   "data.static_methods?": classMembers.handleDataStaticMethods,
   "data.static_properties?": classMembers.handleDataStaticProperties,
   "data.instance_methods?": classMembers.handleDataInstanceMethods,

--- a/scripts/scraper-ng/test/framework/utils.js
+++ b/scripts/scraper-ng/test/framework/utils.js
@@ -66,7 +66,57 @@ function recipePath(recipeName) {
   return path.join(recipesDir, recipeName + ".yaml");
 }
 
+/**
+ * Given an ingredient, an ingredient name and a tag name, check that:
+ * * the ingredient exists
+ * * the ingredient name matches the name given
+ * * the ingredient's position node is an element and its tag matches the given tag.
+ *
+ * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {String} ingredientName - the expected name of the ingredient
+ * @param {String} tagName - the expected tagName of the ingredient's position node
+ */
+function expectPositionElement(ingredient, ingredientName, tagName) {
+  expect(ingredient).toBeDefined();
+  expect(ingredient).toHaveProperty("name", ingredientName);
+  expect(ingredient.position).not.toBeNull();
+  expect(ingredient).toHaveProperty("position.type", "element");
+  expect(ingredient).toHaveProperty("position.tagName", tagName);
+}
+
+/**
+ * Given an ingredient and an ingredient name check that:
+ * * the ingredient exists
+ * * the ingredient name matches the name given
+ *
+ * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {String} ingredientName - the expected name of the ingredient
+ */
+function expectPositionNode(ingredient, ingredientName) {
+  expect(ingredient).toBeDefined();
+  expect(ingredient).toHaveProperty("name", ingredientName);
+  expect(ingredient.position).not.toBeNull();
+}
+
+/**
+ * Given an ingredient and an ingredient name, check that:
+ * * the ingredient exists
+ * * the ingredient name matches the name given
+ * * the ingredient's position node is null.
+ *
+ * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {String} ingredientName - the expected name of the ingredient
+ */
+function expectNullPosition(ingredient, ingredientName) {
+  expect(ingredient).toBeDefined();
+  expect(ingredient).toHaveProperty("name", ingredientName);
+  expect(ingredient).toHaveProperty("position", null);
+}
+
 module.exports = {
   process,
   recipesDir,
+  expectPositionElement,
+  expectNullPosition,
+  expectPositionNode,
 };

--- a/scripts/scraper-ng/test/framework/utils.js
+++ b/scripts/scraper-ng/test/framework/utils.js
@@ -72,7 +72,7 @@ function recipePath(recipeName) {
  * * the ingredient name matches the name given
  * * the ingredient's position node is an element and its tag matches the given tag.
  *
- * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {Object} ingredient - an object representing an ingredient found in a page, including a name and a position node
  * @param {String} ingredientName - the expected name of the ingredient
  * @param {String} tagName - the expected tagName of the ingredient's position node
  */
@@ -89,7 +89,7 @@ function expectPositionElement(ingredient, ingredientName, tagName) {
  * * the ingredient exists
  * * the ingredient name matches the name given
  *
- * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {Object} ingredient - an object representing an ingredient found in a page, including a name and a position node
  * @param {String} ingredientName - the expected name of the ingredient
  */
 function expectPositionNode(ingredient, ingredientName) {
@@ -104,7 +104,7 @@ function expectPositionNode(ingredient, ingredientName) {
  * * the ingredient name matches the name given
  * * the ingredient's position node is null.
  *
- * @param {String} ingredient - an ingredient including a name and a position node
+ * @param {Object} ingredient - an object representing an ingredient found in a page, including a name and a position node
  * @param {String} ingredientName - the expected name of the ingredient
  */
 function expectNullPosition(ingredient, ingredientName) {

--- a/scripts/scraper-ng/test/ingredient-data.browser_compatibility.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.browser_compatibility.test.js
@@ -1,4 +1,8 @@
-const { process } = require("./framework/utils");
+const {
+  process,
+  expectPositionNode,
+  expectNullPosition,
+} = require("./framework/utils");
 
 describe("data.browser_compatibility", () => {
   const testRecipe = { body: ["data.browser_compatibility"] };
@@ -14,10 +18,7 @@ describe("data.browser_compatibility", () => {
 
     expect(file.messages).toStrictEqual([]);
     expect(file).not.hasMessageWithId(/expected-heading/);
-
-    expect(file.data.ingredients).not.toBe(undefined);
-    expect(file.data.ingredients[0]).toHaveProperty("name");
-    expect(file.data.ingredients[0]).toHaveProperty("position");
+    expectPositionNode(file.data.ingredients[0], "data.browser_compatibility");
   });
 
   test("missing heading", () => {
@@ -25,10 +26,7 @@ describe("data.browser_compatibility", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId(/expected-heading/);
-
-    expect(file.data.ingredients).not.toBe(undefined);
-    expect(file.data.ingredients[0]).toHaveProperty("name");
-    expect(file.data.ingredients[0]).toHaveProperty("position", null);
+    expectNullPosition(file.data.ingredients[0], "data.browser_compatibility");
   });
 
   test("missing compat macro", () => {
@@ -40,5 +38,6 @@ describe("data.browser_compatibility", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId(/expected-macro/);
+    expectNullPosition(file.data.ingredients[0], "data.browser_compatibility");
   });
 });

--- a/scripts/scraper-ng/test/ingredient-data.constructor.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constructor.test.js
@@ -1,0 +1,81 @@
+const { process } = require("./framework/utils");
+
+const sources = {
+  valid_constructor: `<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt><a><code>Thing</code></a></dt>
+  <dd>Creates a new <a>Thing</a> object.</dd>
+</dl>`,
+
+  invalid_constructor_section_missing: `<p>Some content</p>`,
+
+  invalid_multiple_constructors: `<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt><a><code>Thing</code></a></dt>
+  <dd>Creates a new <a>Thing</a> object.</dd>
+  <dt><a><code>Thing2</code></a></dt>
+  <dd>Creates a new <a>Thing2</a> object.</dd>
+</dl>`,
+
+  invalid_dd_structure: `<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt><a><code>Thing</code></a></dt>
+  <dd>Creates a new Thing object.</dd>
+</dl>`,
+
+  invalid_dd_content: `<h2 id="Constructor">Constructor</h2>
+<dl>
+  <dt><a><code>Thing</code></a></dt>
+  <dd>Create a <a>Thing</a> object.</dd>
+</dl>`,
+};
+
+describe("data.constructor", () => {
+  const testRecipe = { body: ["data.constructor"] };
+
+  test("valid constructor", () => {
+    const file = process(sources.valid_constructor, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+  });
+
+  test("constructor section missing", () => {
+    const file = process(
+      sources.invalid_constructor_section_missing,
+      testRecipe
+    );
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId("data.constructor/expected-heading");
+  });
+
+  test("multiple constructors", () => {
+    const file = process(sources.invalid_multiple_constructors, testRecipe);
+
+    expect(file.messages.length).toBe(2);
+    expect(file).hasMessageWithId(
+      "data.constructor/only-single-constructor-dt"
+    );
+    expect(file).hasMessageWithId(
+      "data.constructor/only-single-constructor-dd"
+    );
+  });
+
+  test("invalid dd structure", () => {
+    const file = process(sources.invalid_dd_structure, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.constructor/constructor-description-three-nodes"
+    );
+  });
+
+  test("invalid dd content", () => {
+    const file = process(sources.invalid_dd_content, testRecipe);
+
+    expect(file.messages.length).toBe(1);
+    expect(file).hasMessageWithId(
+      "data.constructor/constructor-description-first-node"
+    );
+  });
+});

--- a/scripts/scraper-ng/test/ingredient-data.constructor.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constructor.test.js
@@ -1,4 +1,8 @@
-const { process } = require("./framework/utils");
+const {
+  process,
+  expectPositionElement,
+  expectNullPosition,
+} = require("./framework/utils");
 
 const sources = {
   valid_constructor: `<h2 id="Constructor">Constructor</h2>
@@ -37,6 +41,7 @@ describe("data.constructor", () => {
     const file = process(sources.valid_constructor, testRecipe);
 
     expect(file.messages).toStrictEqual([]);
+    expectPositionElement(file.data.ingredients[0], "data.constructor", "h2");
   });
 
   test("constructor section missing", () => {
@@ -47,6 +52,7 @@ describe("data.constructor", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId("data.constructor/expected-heading");
+    expectNullPosition(file.data.ingredients[0], "data.constructor");
   });
 
   test("multiple constructors", () => {
@@ -68,6 +74,7 @@ describe("data.constructor", () => {
     expect(file).hasMessageWithId(
       "data.constructor/constructor-description-three-nodes"
     );
+    expectNullPosition(file.data.ingredients[0], "data.constructor");
   });
 
   test("invalid dd content", () => {
@@ -77,5 +84,6 @@ describe("data.constructor", () => {
     expect(file).hasMessageWithId(
       "data.constructor/constructor-description-first-node"
     );
+    expectNullPosition(file.data.ingredients[0], "data.constructor");
   });
 });

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -1,4 +1,8 @@
-const { process } = require("./framework/utils");
+const {
+  process,
+  expectPositionElement,
+  expectNullPosition,
+} = require("./framework/utils");
 
 const sources = {
   valid_single_simple: `<h2 id="Examples">Examples</h2>
@@ -50,27 +54,12 @@ const sources = {
 describe("data.examples", () => {
   const testRecipe = { body: ["data.examples"] };
 
-  const expectPosition = (file) => {
-    expect(file.data.ingredients.length).toBe(1);
-    const ingredient = file.data.ingredients[0];
-    expect(ingredient).toHaveProperty("name", "data.examples");
-    expect(ingredient).toHaveProperty("position.type", "element");
-    expect(ingredient).toHaveProperty("position.tagName", "h2");
-  };
-
-  const expectNullPosition = (file) => {
-    expect(file.data.ingredients.length).toBe(1);
-    const ingredient = file.data.ingredients[0];
-    expect(file.data.ingredients[0]).toHaveProperty("name", "data.examples");
-    expect(ingredient).toHaveProperty("position", null);
-  };
-
   test("valid single simple example", () => {
     const file = process(sources.valid_single_simple, testRecipe);
 
     expect(file.messages).toStrictEqual([]);
 
-    expectPosition(file);
+    expectPositionElement(file.data.ingredients[0], "data.examples", "h2");
   });
 
   test("valid multiple simple examples", () => {
@@ -78,7 +67,7 @@ describe("data.examples", () => {
 
     expect(file.messages).toStrictEqual([]);
 
-    expectPosition(file);
+    expectPositionElement(file.data.ingredients[0], "data.examples", "h2");
   });
 
   test("valid multiple live samples", () => {
@@ -88,7 +77,7 @@ describe("data.examples", () => {
     expect(file.messages[0].ruleId).toBe("embedlivesample");
     expect(file.messages[1].ruleId).toBe("embedlivesample");
 
-    expectPosition(file);
+    expectPositionElement(file.data.ingredients[0], "data.examples", "h2");
   });
 
   test("valid mixture of simple and live samples", () => {
@@ -97,7 +86,7 @@ describe("data.examples", () => {
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId(/embedlivesample/);
 
-    expectPosition(file);
+    expectPositionElement(file.data.ingredients[0], "data.examples", "h2");
   });
 
   test("missing Examples H3", () => {
@@ -106,7 +95,7 @@ describe("data.examples", () => {
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId(/data.examples\/missing-example-h3/);
 
-    expectNullPosition(file);
+    expectNullPosition(file.data.ingredients[0], "data.examples");
   });
 
   test("live sample is not final node", () => {
@@ -116,7 +105,7 @@ describe("data.examples", () => {
     expect(file).hasMessageWithId(/embedlivesample/);
     expect(file).hasMessageWithId(/data.examples\/nodes-after-live-sample/);
 
-    expectNullPosition(file);
+    expectNullPosition(file.data.ingredients[0], "data.examples");
   });
 
   test("live sample ID mismatch", () => {
@@ -126,7 +115,7 @@ describe("data.examples", () => {
     expect(file).hasMessageWithId(/embedlivesample/);
     expect(file).hasMessageWithId(/data.examples\/embedlivesample-id-mismatch/);
 
-    expectNullPosition(file);
+    expectNullPosition(file.data.ingredients[0], "data.examples");
   });
 
   test("missing heading", () => {
@@ -135,6 +124,6 @@ describe("data.examples", () => {
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId(/data.examples\/expected-heading/);
 
-    expectNullPosition(file);
+    expectNullPosition(file.data.ingredients[0], "data.examples");
   });
 });


### PR DESCRIPTION
This add a handler for the `data.constructor` ingredient, according to the spec: https://github.com/mdn/stumptown-content/blob/master/project-docs/javascript-linter-spec.md#dataconstructor - well, mostly. I didn't check the value of `NameOfTheObject`, since that looks hard to get, and I thought this would be good enough.

I've deferred some of the checking to the generic link list checker, and added the extra custom checks after that.