### PR TITLE
Update ctor handler to look for <code> instead of <a>

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -46,12 +46,12 @@ function handleDataConstructor(tree, logger) {
     return null;
   }
 
-  // The dd must be of the form: "Creates a new <a>...</a> object."
+  // The dd must be of the form: "Creates a new <code>...</code> object."
   const dd = dds[0];
   if (dd.children.length !== 3) {
     logger.fail(
       dd,
-      "Constructor description must be in the form `Creates a new <a>...</a> object.`",
+      "Constructor description must be in the form `Creates a new <code>...</code> object.`",
       "constructor-description-three-nodes"
     );
     return null;
@@ -60,16 +60,16 @@ function handleDataConstructor(tree, logger) {
   if (!checkText(dd.children[0], "Creates a new ")) {
     logger.fail(
       section,
-      "Constructor description must be in the form 'Creates a new <a>...</a> object.'",
+      "Constructor description must be in the form 'Creates a new <code>...</code> object.'",
       "constructor-description-first-node"
     );
     ok = false;
   }
 
-  if (!checkTag(dd.children[1], "a")) {
+  if (!checkTag(dd.children[1], "code")) {
     logger.fail(
       section,
-      "Constructor description must contain a link after 'Creates a new'",
+      "Constructor description must contain <code>Object</code> after 'Creates a new'",
       "constructor-description-second-node"
     );
     ok = false;

--- a/scripts/scraper-ng/test/ingredient-data.constructor.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constructor.test.js
@@ -8,7 +8,7 @@ const sources = {
   valid_constructor: `<h2 id="Constructor">Constructor</h2>
 <dl>
   <dt><a><code>Thing</code></a></dt>
-  <dd>Creates a new <a>Thing</a> object.</dd>
+  <dd>Creates a new <code>Thing</code> object.</dd>
 </dl>`,
 
   invalid_constructor_section_missing: `<p>Some content</p>`,
@@ -16,9 +16,9 @@ const sources = {
   invalid_multiple_constructors: `<h2 id="Constructor">Constructor</h2>
 <dl>
   <dt><a><code>Thing</code></a></dt>
-  <dd>Creates a new <a>Thing</a> object.</dd>
+  <dd>Creates a new <code>Thing</code> object.</dd>
   <dt><a><code>Thing2</code></a></dt>
-  <dd>Creates a new <a>Thing2</a> object.</dd>
+  <dd>Creates a new <code>Thing2</code> object.</dd>
 </dl>`,
 
   invalid_dd_structure: `<h2 id="Constructor">Constructor</h2>
@@ -30,7 +30,7 @@ const sources = {
   invalid_dd_content: `<h2 id="Constructor">Constructor</h2>
 <dl>
   <dt><a><code>Thing</code></a></dt>
-  <dd>Create a <a>Thing</a> object.</dd>
+  <dd>Create a <code>Thing</code> object.</dd>
 </dl>`,
 };
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Constructor

The `<dd>` should be "Creates a new `BigInt` object." but `BigInt` shouldn't link to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt because that's the same page.

Another thing I wanted to fix, but I don't know how is that the end of the `<dd>` shouldn't be required to be "object.". Imo, we need more freedom there, because sometimes a second sentence follows, see e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#Constructor (and a handful more, these are the last remaining linter errors of this category).