### PR TITLE
Add ingredient handler for prose.description?

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -35,7 +35,7 @@ const ingredientHandlers = {
   "data.specifications": handleDataSpecifications,
   "data.static_methods?": classMembers.handleDataStaticMethods,
   "data.static_properties?": classMembers.handleDataStaticProperties,
-  "prose.description": requireTopLevelHeading("Description"),
+  "prose.description?": optionalTopLevelHeading("Description"),
   "prose.error_type": requireTopLevelHeading("Error_type"),
   "prose.message": requireTopLevelHeading("Message"),
   "prose.see_also": requireTopLevelHeading("See_also"),
@@ -46,9 +46,25 @@ const ingredientHandlers = {
 
 /**
  * A convenience function that returns ingredient handlers for checking
+ * the existence of an optional H2 in a hast tree.
+ *
+ * @param {String} id - an id of an H2 to look for in the hast tree
+ * @returns {Function} a function
+ */
+function optionalTopLevelHeading(id) {
+  return (tree) => {
+    const heading = select(`h2#${id}`, tree);
+    if (heading !== null) {
+      return heading;
+    }
+    return null;
+  };
+}
+
+/**
+ * A convenience function that returns ingredient handlers for checking
  * the existence of a certain H2 in a hast tree.
  *
- * @param {String} ingredient - an ingredient name
  * @param {String} id - an id of an H2 to look for in the hast tree
  * @returns {Function} a function
  */

--- a/scripts/scraper-ng/test/html-require-ingredient-order.test.js
+++ b/scripts/scraper-ng/test/html-require-ingredient-order.test.js
@@ -30,7 +30,7 @@ describe("html-require-ingredient-order", () => {
        <h2 id="Something_else">Something else</h2>
        <h2 id="Description">Description</h2>`,
       {
-        body: ["prose.description", "prose.*", "prose.error_type"],
+        body: ["prose.description?", "prose.*", "prose.error_type"],
       }
     );
 

--- a/scripts/scraper-ng/test/html-require-recipe-ingredients.test.js
+++ b/scripts/scraper-ng/test/html-require-recipe-ingredients.test.js
@@ -72,6 +72,21 @@ describe("html-require-recipe-ingredients logs recipe positions", () => {
     expect(ingredient).toHaveProperty("position.tagName", "h2");
   });
 
+  test("prose.description?", () => {
+    const ingredientName = "prose.description?";
+    const source = '<h2 id="Description">Description</h2>';
+    const file = process(source, { body: [ingredientName] });
+
+    expect(file).not.hasMessageWithId(ingredientName);
+
+    expect(file.data.ingredients.length).toBe(1);
+
+    const ingredient = file.data.ingredients[0];
+    expect(ingredient).toHaveProperty("name", ingredientName);
+    expect(ingredient).toHaveProperty("position.type", "element");
+    expect(ingredient).toHaveProperty("position.tagName", "h2");
+  });
+
   test("prose.short_description", () => {
     const source = `<div>{{JSRef}}</div>
 
@@ -105,4 +120,10 @@ describe("html-require-recipe-ingredients logs recipe positions", () => {
     expect(ingredient).toHaveProperty("position.type", "element");
     expect(ingredient).toHaveProperty("position.tagName", "h2");
   });
+});
+
+test("html-require-recipe-ingredients optional ingredients don't error when missing", () => {
+  const source = "<p>Nothing to see here.</p>";
+  const file = process(source, { body: ["prose.description?"] });
+  expect(file).not.hasMessageWithId("prose.description?");
 });


### PR DESCRIPTION
This PR adds an ingredient handler for the `prose.description?` ingredient. I wrote a generic optional prose section handler factory because I expect this won't be the only heading we'll want to flag as optional.

Fixes #409.