### PR TITLE
Lint prose.* order

### DIFF
--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -1,7 +1,5 @@
 const path = require("path");
 
-const { selectAll } = require("hast-util-select");
-
 const source = "html-require-ingredient-order";
 
 /**
@@ -10,9 +8,7 @@ const source = "html-require-ingredient-order";
  */
 function attacher() {
   return function lintIngredientOrder(tree, file) {
-    file.data.ingredients.push(...collectProseStar(tree, file));
-
-    // Collect all page ingredients with positions
+    // Collect only those page ingredients with positions
     const pageIngredients = file.data.ingredients
       .filter((i) => i.position !== null)
       .sort((a, b) => a.position.data.pageIndex - b.position.data.pageIndex); // Sorted by their order on the page
@@ -57,50 +53,6 @@ function attacher() {
       }
     }
   };
-}
-
-// Ingredients that do not have a corresponding H2 element
-const ingredientsWithoutH2s = [
-  "prose.*",
-  "prose.short_descriptions",
-  "data.interactive_example",
-];
-
-/**
- * Collect H2s not otherwise expected in an ingredient.
- *
- * @param {Object} tree - A hast tree
- * @param {vfile} file - A vfile with a `file.data.ingredients` array and a `file.data.recipe` object
- * @returns {Array} an array of `file.data.ingredients` member-like objects with `name` and `position` properties
- */
-function collectProseStar(tree, file) {
-  const reservedIds = file.data.recipe.body
-    .filter((i) => !ingredientsWithoutH2s.includes(i))
-    .map(ingredientToSelector);
-
-  const proseStars = [];
-  for (const h2 of selectAll(`h2:not(${reservedIds.join()})`, tree)) {
-    proseStars.push({
-      name: "prose.*",
-      position: h2,
-    });
-  }
-
-  return proseStars;
-}
-
-/**
- * Convert an ingredient identifier to an ID selector.
- *
- * For example, `ingredientToSelector("prose.syntax")`  returns `"#Syntax"`.
- *
- * @param {string} ingredient - an ingredient identifier, such as `prose.description?` or `data.browser_compatibility`
- * @returns {string} an ID selector string
- */
-function ingredientToSelector(ingredient) {
-  const { name } = ingredient.match(/[.](?<name>\w+)/).groups;
-  const id = name.charAt(0).toUpperCase() + name.slice(1);
-  return `#${id}`;
 }
 
 module.exports = attacher;

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -6,33 +6,28 @@ const source = "html-require-ingredient-order";
 
 /**
  * A plugin that sets an error when an ingredient appears before or after another ingredient.
+ *
  */
 function attacher() {
   return function lintIngredientOrder(tree, file) {
-    // TODO: I decided to treat all H2s not identified as another ingredient as a `prose.*` ingredient
     file.data.ingredients.push(...collectProseStar(tree, file));
 
-    // Collect all the page ingredients actually found on the page (the set of known + prose.*, excluding missing)
+    // Collect all page ingredients with positions
     const pageIngredients = file.data.ingredients
       .filter((i) => i.position !== null)
       .sort((a, b) => a.position.data.pageIndex - b.position.data.pageIndex); // Sorted by their order on the page
-    const pageIngredientNames = new Set(pageIngredients.map((i) => i.name));
 
     // Get the sequence of expected recipe ingredients, excluding those that
     // definitely don't appear in the page. This skips both 1) optional
     // ingredients that were omitted (which is permissible) and 2) required
-    // ingredients that weren't found
+    // ingredients that are missing (which is out-of-scope for this rule)
+    const pageIngredientNames = new Set(pageIngredients.map((i) => i.name));
     const recipeIngredientNames = file.data.recipe.body.filter((i) =>
       pageIngredientNames.has(i)
     );
 
-    // TODO: Filter the names of expected recipe ingredients by the list of known ingredient names
-    // TODO: Pop r1 and i1 and compare. Are they the same name?
-    // TODO: If r is prose.* and i is prose.* --> continue as long as i is prose.*, then pop r
-    // TODO: elif r !== i --> error, then pop
-    // TODO: continue until empty
-
-    // In the list of expected ingredients, replace `prose.*` with a sufficient number of `prose.*` entries to cover all such ingredients
+    // Pad the sequence of expected ingredients with additioanl `prose.*`
+    // entries to cover all such ingredients
     if (recipeIngredientNames.includes("prose.*")) {
       const padCount = pageIngredients.reduce(
         (sum, ingredient) => sum + (ingredient.name == "prose.*" ? 1 : 0),
@@ -45,18 +40,6 @@ function attacher() {
       );
     }
 
-    const output = [];
-    for (
-      let index = 0;
-      index < Math.max(recipeIngredientNames.length, pageIngredients.length);
-      index++
-    ) {
-      const recipe = recipeIngredientNames[index];
-      const ingredient = pageIngredients[index].name;
-      output.push([recipe, ingredient]);
-    }
-    console.log(output);
-
     for (
       let index = 0;
       index < Math.max(recipeIngredientNames.length, pageIngredients.length);
@@ -66,9 +49,6 @@ function attacher() {
       const currentIngredient = pageIngredients[index];
 
       if (currentIngredient.name !== expectedIngredientName) {
-        console.log(
-          `Logging ${expectedIngredientName}, ${currentIngredient.name}`
-        );
         const message = file.message(
           `${currentIngredient.name} not expected in this order`,
           currentIngredient.position,

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -26,7 +26,7 @@ function attacher() {
     // entries to cover all such ingredients
     if (recipeIngredientNames.includes("prose.*")) {
       const padCount = pageIngredients.reduce(
-        (sum, ingredient) => sum + (ingredient.name == "prose.*" ? 1 : 0),
+        (sum, ingredient) => sum + (ingredient.name === "prose.*" ? 1 : 0),
         0
       );
       recipeIngredientNames.splice(

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -22,7 +22,7 @@ function attacher() {
       pageIngredientNames.has(i)
     );
 
-    // Pad the sequence of expected ingredients with additioanl `prose.*`
+    // Pad the sequence of expected ingredients with additional `prose.*`
     // entries to cover all such ingredients
     if (recipeIngredientNames.includes("prose.*")) {
       const padCount = pageIngredients.reduce(

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -41,8 +41,12 @@ function attacher() {
       const currentIngredient = pageIngredients[index];
 
       if (currentIngredient.name !== expectedIngredientName) {
+        const extraInfoForProseStar =
+          currentIngredient.name === "prose.*"
+            ? ` (#${currentIngredient.position.properties.id})`
+            : "";
         const message = file.message(
-          `${currentIngredient.name} not expected in this order`,
+          `${currentIngredient.name}${extraInfoForProseStar} not expected in this order`,
           currentIngredient.position,
           `${source}:${path.basename(
             file.data.recipePath,

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -1,5 +1,7 @@
 const path = require("path");
 
+const { selectAll } = require("hast-util-select");
+
 const source = "html-require-ingredient-order";
 
 /**
@@ -7,24 +9,66 @@ const source = "html-require-ingredient-order";
  */
 function attacher() {
   return function lintIngredientOrder(tree, file) {
+    // TODO: I decided to treat all H2s not identified as another ingredient as a `prose.*` ingredient
+    file.data.ingredients.push(...collectProseStar(tree, file));
+
+    // Collect all the page ingredients actually found on the page (the set of known + prose.*, excluding missing)
     const pageIngredients = file.data.ingredients
-      .filter((i) => i.position !== null) // Skip checking the order of ingredients that weren't found
-      .sort((a, b) => a.position.data.pageIndex - b.position.data.pageIndex); // Sort found ingredients by their order on the page
+      .filter((i) => i.position !== null)
+      .sort((a, b) => a.position.data.pageIndex - b.position.data.pageIndex); // Sorted by their order on the page
+    const pageIngredientNames = new Set(pageIngredients.map((i) => i.name));
 
-    // Filter the recipe's sequence of ingredients to only the ingredients found
-    // in the page
-    const pageIngredientNames = pageIngredients.map(
-      (ingredient) => ingredient.name
+    // Get the sequence of expected recipe ingredients, excluding those that
+    // definitely don't appear in the page. This skips both 1) optional
+    // ingredients that were omitted (which is permissible) and 2) required
+    // ingredients that weren't found
+    const recipeIngredientNames = file.data.recipe.body.filter((i) =>
+      pageIngredientNames.has(i)
     );
-    const recipeIngredientNames = file.data.recipe.body.filter((ingredient) =>
-      pageIngredientNames.includes(ingredient)
-    );
 
-    for (let i = 0; i < pageIngredients.length; i++) {
-      const currentIngredient = pageIngredients[i];
-      const expectedIngredient = recipeIngredientNames[i];
+    // TODO: Filter the names of expected recipe ingredients by the list of known ingredient names
+    // TODO: Pop r1 and i1 and compare. Are they the same name?
+    // TODO: If r is prose.* and i is prose.* --> continue as long as i is prose.*, then pop r
+    // TODO: elif r !== i --> error, then pop
+    // TODO: continue until empty
 
-      if (currentIngredient.name !== expectedIngredient) {
+    // In the list of expected ingredients, replace `prose.*` with a sufficient number of `prose.*` entries to cover all such ingredients
+    if (recipeIngredientNames.includes("prose.*")) {
+      const padCount = pageIngredients.reduce(
+        (sum, ingredient) => sum + (ingredient.name == "prose.*" ? 1 : 0),
+        0
+      );
+      recipeIngredientNames.splice(
+        recipeIngredientNames.indexOf("prose.*"),
+        1,
+        ...new Array(padCount).fill("prose.*")
+      );
+    }
+
+    const output = [];
+    for (
+      let index = 0;
+      index < Math.max(recipeIngredientNames.length, pageIngredients.length);
+      index++
+    ) {
+      const recipe = recipeIngredientNames[index];
+      const ingredient = pageIngredients[index].name;
+      output.push([recipe, ingredient]);
+    }
+    console.log(output);
+
+    for (
+      let index = 0;
+      index < Math.max(recipeIngredientNames.length, pageIngredients.length);
+      index++
+    ) {
+      const expectedIngredientName = recipeIngredientNames[index];
+      const currentIngredient = pageIngredients[index];
+
+      if (currentIngredient.name !== expectedIngredientName) {
+        console.log(
+          `Logging ${expectedIngredientName}, ${currentIngredient.name}`
+        );
         const message = file.message(
           `${currentIngredient.name} not expected in this order`,
           currentIngredient.position,
@@ -37,6 +81,47 @@ function attacher() {
       }
     }
   };
+}
+
+const ingredientsWithoutDefinedH2s = [
+  "prose.*",
+  "prose.short_descriptions",
+  "data.interactive_example",
+];
+
+function collectProseStar(tree, file) {
+  const reservedH2s = [];
+  for (const ingredient of file.data.recipe.body) {
+    if (!ingredientsWithoutDefinedH2s.includes(ingredient)) {
+      const { name } = ingredient.match(/[.](?<name>\w+)/).groups;
+      const id = name.charAt(0).toUpperCase() + name.slice(1);
+      reservedH2s.push(id);
+    }
+  }
+
+  const h2s = selectAll("h2", tree);
+  const ingredientNodes = file.data.ingredients.reduce((arr, curr) => {
+    if (curr.position !== null) {
+      arr.push(curr.position);
+    }
+    return arr;
+  }, []);
+
+  // Collect all H2 nodes that are not known to represent an existing ingredient or have a reserved ID
+  let proseStars = [];
+  for (const h2 of h2s) {
+    if (
+      !ingredientNodes.includes(h2) &&
+      !reservedH2s.includes(h2.properties.id)
+    ) {
+      proseStars.push({
+        name: "prose.*",
+        position: h2,
+      });
+    }
+  }
+
+  return proseStars;
 }
 
 module.exports = attacher;

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -90,16 +90,16 @@ const ingredientsWithoutDefinedH2s = [
 ];
 
 function collectProseStar(tree, file) {
-  const reservedH2s = [];
+  const reservedIds = [];
   for (const ingredient of file.data.recipe.body) {
     if (!ingredientsWithoutDefinedH2s.includes(ingredient)) {
       const { name } = ingredient.match(/[.](?<name>\w+)/).groups;
-      const id = name.charAt(0).toUpperCase() + name.slice(1);
-      reservedH2s.push(id);
+      const id = `#${name.charAt(0).toUpperCase() + name.slice(1)}`;
+      reservedIds.push(id);
     }
   }
 
-  const h2s = selectAll("h2", tree);
+  const h2s = selectAll(`h2:not(${reservedIds.join()})`, tree);
   const ingredientNodes = file.data.ingredients.reduce((arr, curr) => {
     if (curr.position !== null) {
       arr.push(curr.position);
@@ -110,10 +110,7 @@ function collectProseStar(tree, file) {
   // Collect all H2 nodes that are not known to represent an existing ingredient or have a reserved ID
   let proseStars = [];
   for (const h2 of h2s) {
-    if (
-      !ingredientNodes.includes(h2) &&
-      !reservedH2s.includes(h2.properties.id)
-    ) {
+    if (!ingredientNodes.includes(h2)) {
       proseStars.push({
         name: "prose.*",
         position: h2,

--- a/scripts/scraper-ng/rules/html-require-ingredient-order.js
+++ b/scripts/scraper-ng/rules/html-require-ingredient-order.js
@@ -40,11 +40,7 @@ function attacher() {
       );
     }
 
-    for (
-      let index = 0;
-      index < Math.max(recipeIngredientNames.length, pageIngredients.length);
-      index++
-    ) {
+    for (let index = 0; index < recipeIngredientNames.length; index++) {
       const expectedIngredientName = recipeIngredientNames[index];
       const currentIngredient = pageIngredients[index];
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
@@ -29,6 +29,8 @@ function requireRecipeIngredientsPlugin() {
       } else {
         const rule = `${recipeName}/${ingredient}/handler-not-implemented`;
         const origin = `${source}:${rule}`;
+        // TODO: we now have handlers for all specified ingredients, so this
+        // should be file.fail
         file.message(`Handler for ${ingredient} is unimplemented`, origin);
       }
     }

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
 const ingredientHandlers = require("./ingredient-handlers");
+const collectProseStar = require("./ingredient-handlers/prose-star");
 const { Logger } = require("./ingredient-handlers/utils");
 
 const source = "html-require-ingredient";
@@ -12,14 +13,12 @@ function requireRecipeIngredientsPlugin() {
   return function warnOnMissingRecipeIngredients(tree, file) {
     const recipeName = path.basename(file.data.recipePath, ".yaml");
 
-    const requiredBody = file.data.recipe.body.filter(
-      (ingredientName) => !ingredientName.endsWith(".*")
-    );
-
     file.data.ingredients = [];
 
-    for (const ingredient of requiredBody) {
-      if (ingredient in ingredientHandlers) {
+    for (const ingredient of file.data.recipe.body) {
+      if (ingredient === "prose.*") {
+        file.data.ingredients.push(...collectProseStar(tree, file));
+      } else if (ingredient in ingredientHandlers) {
         const logger = Logger(file, source, recipeName, ingredient);
         const position = ingredientHandlers[ingredient](tree, logger);
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-star.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-star.js
@@ -3,7 +3,7 @@ const { selectAll } = require("hast-util-select");
 // Ingredients that do not have a corresponding H2 element
 const ingredientsWithoutH2s = [
   "prose.*",
-  "prose.short_descriptions",
+  "prose.short_description",
   "data.interactive_example",
 ];
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-star.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/prose-star.js
@@ -1,0 +1,47 @@
+const { selectAll } = require("hast-util-select");
+
+// Ingredients that do not have a corresponding H2 element
+const ingredientsWithoutH2s = [
+  "prose.*",
+  "prose.short_descriptions",
+  "data.interactive_example",
+];
+
+/**
+ * Collect H2s not otherwise expected in an ingredient.
+ *
+ * @param {Object} tree - A hast tree
+ * @param {vfile} file - A vfile with a `file.data.ingredients` array and a `file.data.recipe` object
+ * @returns {Array} an array of `file.data.ingredients` member-like objects with `name` and `position` properties
+ */
+function collectProseStar(tree, file) {
+  const reservedIds = file.data.recipe.body
+    .filter((i) => !ingredientsWithoutH2s.includes(i))
+    .map(ingredientToSelector);
+
+  const proseStars = [];
+  for (const h2 of selectAll(`h2:not(${reservedIds.join()})`, tree)) {
+    proseStars.push({
+      name: "prose.*",
+      position: h2,
+    });
+  }
+
+  return proseStars;
+}
+
+/**
+ * Convert an ingredient identifier to an ID selector.
+ *
+ * For example, `ingredientToSelector("prose.syntax")`  returns `"#Syntax"`.
+ *
+ * @param {string} ingredient - an ingredient identifier, such as `prose.description?` or `data.browser_compatibility`
+ * @returns {string} an ID selector string
+ */
+function ingredientToSelector(ingredient) {
+  const { name } = ingredient.match(/[.](?<name>\w+)/).groups;
+  const id = name.charAt(0).toUpperCase() + name.slice(1);
+  return `#${id}`;
+}
+
+module.exports = collectProseStar;

--- a/scripts/scraper-ng/test/html-require-ingredient-order.test.js
+++ b/scripts/scraper-ng/test/html-require-ingredient-order.test.js
@@ -37,16 +37,41 @@ describe("html-require-ingredient-order", () => {
     expect(file).hasMessageWithId("ingredient-out-of-order");
   });
 
-  // test("prose.* ingredient disorder", () => {
-  //   const file = process(
-  //     `<h2 id="Description">Description</h2>
-  //      <h2 id="Error_type">Error type</h2>
-  //      <h2 id="Something_else">Something else</h2>`,
-  //     {
-  //       body: ["prose.description", "prose.*", "prose.error_type"],
-  //     }
-  //   );
+  test("optional ingredient disorder causes message", () => {
+    const file = process(
+      `<h2 id="Error_type">Error type</h2>
+       <h2 id="Description">Description</h2>`,
+      {
+        body: ["prose.description?", "prose.error_type"],
+      }
+    );
 
-  //   expect(file).hasMessageWithId("ingredient-out-of-order");
-  // });
+    expect(file).hasMessageWithId("ingredient-out-of-order");
+  });
+
+  test("prose.* ingredient order is OK", () => {
+    const file = process(
+      `<h2 id="Description">Description</h2>
+       <h2 id="Something_else">Something else</h2>
+       <h2 id="Error_type">Error type</h2>`,
+      {
+        body: ["prose.description?", "prose.*", "prose.error_type"],
+      }
+    );
+
+    expect(file).not.hasMessageWithId("ingredient-out-of-order");
+  });
+
+  test("prose.* ingredient disorder causes message", () => {
+    const file = process(
+      `<h2 id="Description">Description</h2>
+       <h2 id="Error_type">Error type</h2>
+       <h2 id="Something_else">Something else</h2>`,
+      {
+        body: ["prose.description?", "prose.*", "prose.error_type"],
+      }
+    );
+
+    expect(file).hasMessageWithId("ingredient-out-of-order");
+  });
 });


### PR DESCRIPTION
This PR adds a handler (of sorts) for `prose.*` ingredients, which allows for the linting of `prose.*` headings. With this PR, all ingredients can be linted for order. This fixes #338.

## Notes

* I was really glad we had the stumptown call this week. It gave me an idea of how to structure this such that none of the existing tests required changes. 🎉
* The diff is not quite as clean I would've liked. I got to my solution a bit circuitously, so there are a few lines changed that aren't really germane. I can revert them, if they're distracting.
* Unlike the previous PR for linting order, this one actually helped me discover some pages with problems, such as [parseInt](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) (where the `prose.*` sections appear after examples, instead of before) or [AggregateError](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) (which can't decide if it's class page or a constructor page).
* Possible follow up: For all the specified ingredients, we now have handlers. If we want to, we can throw proper exceptions for undhandled ingredients. This is probably a good idea, but it requires reworking a few tests that didn't seem relevant here, or dumping our old HTML or CSS recipes (which would impact other things and be controversial). In any case, I left a TODO comment about it.