### PR TITLE
Update the linter to accept classes with no constructor, if this is explicitly mentioned

### DIFF
--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -124,14 +124,16 @@ To satisfy this ingredient a page must have a section demarcated by `H2#Constitu
 
 #### data.constructor
 
-To satisfy this ingredient, a page must meet the following requirements:
+To satisfy this ingredient, a page must contain a section demarcated by `H2#Constructor` that contains one of the following:
 
-- A section demarcated by `H2#Constructor` that contains only a `<dl>` element.
-- The `<dl>` must contain a single `<dt>` followed by a single `<dd>`.
-- The `<dt>` must contain either:
-  - only a single `<code>` element, that contains only a single `<a>` element
-  - only a call to the `{{jsxref}}` macro.
-- The `<dd>` must contain `Creates a new <code>NameOfTheObject</code> object.` where `NameOfTheObject` is replaced with the actual name.
+1. Only a `<dl>` element.
+   - The `<dl>` must contain a single `<dt>` followed by a single `<dd>`.
+   - The `<dt>` must contain either:
+     - only a single `<code>` element, that contains only a single `<a>` element
+     - only a call to the `{{jsxref}}` macro.
+   - The `<dd>` must contain `Creates a new <code>NameOfTheObject</code> object.` where `NameOfTheObject` is replaced with the actual name.
+
+2) A `<p>` element that starts with the text "This object cannot be instantiated directly.".
 
 #### data.constructor_properties?
 

--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -133,7 +133,7 @@ To satisfy this ingredient, a page must contain a section demarcated by `H2#Cons
      - only a call to the `{{jsxref}}` macro.
    - The `<dd>` must contain `Creates a new <code>NameOfTheObject</code> object.` where `NameOfTheObject` is replaced with the actual name.
 
-2) A `<p>` element that starts with the text "This object cannot be instantiated directly.".
+2. A `<p>` element that starts with the text "This object cannot be instantiated directly.".
 
 #### data.constructor_properties?
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -45,14 +45,13 @@ function handleDataConstructor(tree, logger) {
 
   // Constructor sections are allowed to have no actual links
   // to constructors, if they explicitly record this fact
-  let ok = checkNoConstructor(section.children);
-  if (ok) {
+  if (checkNoConstructor(section.children)) {
     return heading;
   }
   // Otherwise they must include a link to a constructor
 
   // Check common link list structure
-  ok = checkLinkList("Constructor", tree, logger);
+  let ok = checkLinkList("Constructor", tree, logger);
 
   // This link list is only allowed one entry
   const dts = select.selectAll("dt", section);

--- a/scripts/scraper-ng/test/ingredient-data.constructor.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constructor.test.js
@@ -11,6 +11,10 @@ const sources = {
   <dd>Creates a new <code>Thing</code> object. Some additional explanation.</dd>
 </dl>`,
 
+  valid_constructor_link_omitted: `<h2 id="Constructor">Constructor</h2>
+<p>This object cannot be instantiated directly.</p>
+<ul><li>Some more random content is allowed here</li></ul>`,
+
   invalid_constructor_section_missing: `<p>Some content</p>`,
 
   invalid_multiple_constructors: `<h2 id="Constructor">Constructor</h2>
@@ -39,6 +43,13 @@ describe("data.constructor", () => {
 
   test("valid constructor", () => {
     const file = process(sources.valid_constructor, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+    expectPositionElement(file.data.ingredients[0], "data.constructor", "h2");
+  });
+
+  test("valid constructor with no link", () => {
+    const file = process(sources.valid_constructor_link_omitted, testRecipe);
 
     expect(file.messages).toStrictEqual([]);
     expectPositionElement(file.data.ingredients[0], "data.constructor", "h2");


### PR DESCRIPTION
See https://github.com/mdn/stumptown-content/issues/447#issuecomment-632927388.

This makes the linter accept, as an alternative to a `<dl>` containing a link to  constructor, a `<p>` that starts with text like "This object cannot be instantiated directly." (which is expected to be followed by some more text providing extra context).

This will enable us to fix linter errors for:

* [TypedArray](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
* [Generator](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator)
