### PR TITLE
Allow 'value' in the text for a constructor link

### DIFF
--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -131,9 +131,9 @@ To satisfy this ingredient, a page must contain a section demarcated by `H2#Cons
    - The `<dt>` must contain either:
      - only a single `<code>` element, that contains only a single `<a>` element
      - only a call to the `{{jsxref}}` macro.
-   - The `<dd>` must contain `Creates a new <code>NameOfTheObject</code> object.` where `NameOfTheObject` is replaced with the actual name.
+   - The `<dd>` must contain either `Creates a new <code>NameOfTheObject</code> object.` or `Creates a new <code>NameOfTheObject</code> value.` where `NameOfTheObject` is replaced with the actual name.
 
-2. A `<p>` element that starts with the text "This object cannot be instantiated directly.".
+2) A `<p>` element that starts with the text "This object cannot be instantiated directly.".
 
 #### data.constructor_properties?
 

--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -133,7 +133,7 @@ To satisfy this ingredient, a page must contain a section demarcated by `H2#Cons
      - only a call to the `{{jsxref}}` macro.
    - The `<dd>` must contain either `Creates a new <code>NameOfTheObject</code> object.` or `Creates a new <code>NameOfTheObject</code> value.` where `NameOfTheObject` is replaced with the actual name.
 
-2) A `<p>` element that starts with the text "This object cannot be instantiated directly.".
+2. A `<p>` element that starts with the text "This object cannot be instantiated directly.".
 
 #### data.constructor_properties?
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -102,10 +102,15 @@ function handleDataConstructor(tree, logger) {
     ok = false;
   }
 
-  if (!startsWithText(dd.children[2], " object.")) {
+  if (
+    !(
+      startsWithText(dd.children[2], " object.") ||
+      startsWithText(dd.children[2], " value.")
+    )
+  ) {
     logger.fail(
       section,
-      "Constructor description must end first sentence with ' object.'",
+      "Constructor description must end first sentence with ' object.' or ' value.'",
       "constructor-description-third-node"
     );
     ok = false;

--- a/scripts/scraper-ng/test/ingredient-data.constructor.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constructor.test.js
@@ -5,10 +5,16 @@ const {
 } = require("./framework/utils");
 
 const sources = {
-  valid_constructor: `<h2 id="Constructor">Constructor</h2>
+  valid_constructor_with_object: `<h2 id="Constructor">Constructor</h2>
 <dl>
   <dt><a><code>Thing</code></a></dt>
   <dd>Creates a new <code>Thing</code> object. Some additional explanation.</dd>
+</dl>`,
+
+  valid_constructor_with_value: `<h2 id="Constructor">Constructor</h2>
+<dl>
+<dt><a><code>Thing</code></a></dt>
+<dd>Creates a new <code>Thing</code> value. Some additional explanation.</dd>
 </dl>`,
 
   valid_constructor_link_omitted: `<h2 id="Constructor">Constructor</h2>
@@ -41,8 +47,15 @@ const sources = {
 describe("data.constructor", () => {
   const testRecipe = { body: ["data.constructor"] };
 
-  test("valid constructor", () => {
-    const file = process(sources.valid_constructor, testRecipe);
+  test("valid constructor using 'object'", () => {
+    const file = process(sources.valid_constructor_with_object, testRecipe);
+
+    expect(file.messages).toStrictEqual([]);
+    expectPositionElement(file.data.ingredients[0], "data.constructor", "h2");
+  });
+
+  test("valid constructor using 'value'", () => {
+    const file = process(sources.valid_constructor_with_value, testRecipe);
 
     expect(file.messages).toStrictEqual([]);
     expectPositionElement(file.data.ingredients[0], "data.constructor", "h2");


### PR DESCRIPTION
As discussed in https://github.com/mdn/stumptown-content/issues/459, this makes the linter tolerate "value" as well as "object" in the description of links to constructors.

I love having tests.