### PR TITLE
Remove data.examples from javascript-namespace recipe

### DIFF
--- a/recipes/javascript-namespace.yaml
+++ b/recipes/javascript-namespace.yaml
@@ -11,7 +11,6 @@ body:
   - data.static_properties?
   - data.static_methods?
   - prose.*
-  - data.examples
   - data.specifications
   - data.browser_compatibility
   - prose.see_also


### PR DESCRIPTION
This removes `data.examples` from the namespace recipe for JavaScript pages. From https://github.com/mdn/stumptown-content/issues/411#issuecomment-635921346. I don't know if we should do this.

Pros:
- Namespaces can't be instantiated, so namespace examples may duplicate individual method and property pages
- As best I can tell, namespace pages didn't have any examples until we started fixing linter errors. It seems poor form for the recipe to require them, if no such page ever had examples before

Cons:
- It might be nice to have examples that tie different pieces of an namespace together