### PR TITLE
Map page tags to CSS property recipes

### DIFF
--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -55,6 +55,18 @@ const signatures = [
       tags: ["Guide"],
     },
   },
+  {
+    recipePath: recipe("css-shorthand-property"),
+    conditions: {
+      tags: ["CSS", "Shorthand property"],
+    },
+  },
+  {
+    recipePath: recipe("css-property"),
+    conditions: {
+      tags: ["CSS", "Property"],
+    },
+  },
 ];
 
 /**

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -2,9 +2,21 @@ const path = require("path");
 
 const signatures = [
   {
-    recipePath: recipe("javascript-namespace"),
+    recipePath: recipe("css-property"),
     conditions: {
-      tags: ["JavaScript", "Namespace"],
+      tags: ["CSS", "Property"],
+    },
+  },
+  {
+    recipePath: recipe("css-shorthand-property"),
+    conditions: {
+      tags: ["CSS", "Shorthand property"],
+    },
+  },
+  {
+    recipePath: recipe("guide"),
+    conditions: {
+      tags: ["Guide"],
     },
   },
   {
@@ -26,9 +38,21 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("javascript-language-feature"),
+    conditions: {
+      tags: ["JavaScript", "Language feature"],
+    },
+  },
+  {
     recipePath: recipe("javascript-method"),
     conditions: {
       tags: ["JavaScript", "Method"],
+    },
+  },
+  {
+    recipePath: recipe("javascript-namespace"),
+    conditions: {
+      tags: ["JavaScript", "Namespace"],
     },
   },
   {
@@ -38,33 +62,9 @@ const signatures = [
     },
   },
   {
-    recipePath: recipe("javascript-language-feature"),
-    conditions: {
-      tags: ["JavaScript", "Language feature"],
-    },
-  },
-  {
     recipePath: recipe("landing-page"),
     conditions: {
       tags: ["Landing page"],
-    },
-  },
-  {
-    recipePath: recipe("guide"),
-    conditions: {
-      tags: ["Guide"],
-    },
-  },
-  {
-    recipePath: recipe("css-shorthand-property"),
-    conditions: {
-      tags: ["CSS", "Shorthand property"],
-    },
-  },
-  {
-    recipePath: recipe("css-property"),
-    conditions: {
-      tags: ["CSS", "Property"],
     },
   },
 ];

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -4,13 +4,13 @@ const signatures = [
   {
     recipePath: recipe("css-property"),
     conditions: {
-      tags: ["CSS", "Property"],
+      tags: ["recipe:css-property"],
     },
   },
   {
     recipePath: recipe("css-shorthand-property"),
     conditions: {
-      tags: ["CSS", "Shorthand property"],
+      tags: ["recipe:css-shorthand-property"],
     },
   },
   {


### PR DESCRIPTION
We don't have a complete set of CSS page recipes yet. But we do have recipes for CSS properties and CSS shorthand properties. So this PR adds mappings from page tags to these two recipes.

It uses:
* ["CSS", "Property"] to identify a CSS property page
* ["CSS", "Shorthand property"] to identify a CSS shorthand property page

Having this landed would unblock work to fix all the page tags for these types, which is a possible work item for a doc sprint in the virtual all-hands.

Having page tags fixed is also of course a prerequisite for being able to generate linter errors for these pages, and fixing those errors is another possible work item for a doc sprint.

It's worth considering whether the tags I've chosen here are correct. In particular this choice means we don't tag shorthand properties with "Property", which could potentially break macros that rely on tags. IIRC our CSS docs rely on tags more than other areas, because of the completely flat hierarchy. But from a quick look at macros like [CSSInfo](https://github.com/mdn/kumascript/blob/master/macros/CSSInfo.ejs), [CSSSyntax](https://github.com/mdn/kumascript/blob/master/macros/CSSSyntax.ejs), [CSSRef](https://github.com/mdn/kumascript/blob/master/macros/CSSRef.ejs), [CSS_Ref](https://github.com/mdn/kumascript/blob/master/macros/CSS_Ref.ejs), noone there seems to be relying on "Property" as a tag name. And our tagging is such a mess that anything that relies on correct tags is probably broken anyway.

As an alternative we could give shorthand properties something like ["CSS", "Property", "Shorthand"]. But then the linter would need to be cleverer in how it applies the mapping. Maybe it's worth it?

[In a separate commit](https://github.com/mdn/stumptown-content/commits?author=wbamberg), I also alphabetised the array of mappings, because otherwise things will get weird.