### PR TITLE
Add handler for data.formal_syntax

### DIFF
--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -163,7 +163,7 @@ To satisfy this ingredient a page must have a section demarcated by `H2#Formal_d
 
 #### data.formal_syntax
 
-To satisfy this ingredient a page must have a section demarcated by `H2#Formal_syntax`. It must contain only a call to the `{{CSSSyntax}}` macro.
+To satisfy this ingredient a page must have a section demarcated by `H2#Formal_syntax`. It must contain only a single `<pre class="syntaxbox">`, itself containing a single `{{CSSSyntax}}` macro call.
 
 #### data.instance_methods?
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
@@ -1,3 +1,77 @@
-function handleDataFormalSyntax(tree, logger) {}
+const { isMacro, sliceSection } = require("./utils");
+const { select } = require("hast-util-select");
+const visit = require("unist-util-visit");
+
+function handleDataFormalSyntax(tree, logger) {
+  const id = "Formal_syntax";
+  const body = select(`body`, tree);
+  const heading = select(`h2#${id}`, body);
+  const section = sliceSection(heading, body);
+
+  if (heading === null) {
+    logger.expected(body, `h2#${id}`, "expected-heading");
+    return null;
+  }
+
+  // The first non-whitespace node after the `h2` must be pre.syntaxbox
+  const relevantChildren = section.children.filter(
+    (child) => child.tagName !== "h2" && !isWhiteSpaceTextNode(child)
+  );
+  const expectedPre = relevantChildren.length > 0 ? relevantChildren[0] : null;
+  if (
+    expectedPre === null ||
+    expectedPre.type !== "element" ||
+    expectedPre.tagName !== "pre" ||
+    !Array.isArray(expectedPre.properties.className) ||
+    !expectedPre.properties.className.includes("syntaxbox")
+  ) {
+    logger.expected(tree, expectedPre, "expected-pre.syntaxbox");
+    return null;
+  }
+
+  // The `pre` tag's first child must be a macro node
+  const expectedMacro =
+    expectedPre.children.length > 0 ? expectedPre.children[0] : null;
+  if (expectedMacro === null || !isMacro(expectedMacro, "CSSSyntax")) {
+    logger.expected(tree, expectedPre, "expected-macro");
+    return null;
+  }
+
+  // Do not allow any nodes other than the expected `<h2/><pre>{{macro}}</pre>`
+  let extraneousNode = null;
+  visit(
+    section,
+    (node) => node.type !== "root",
+    (node) => {
+      if (node === heading) {
+        return visit.SKIP; // ignore the heading text
+      }
+      if (
+        isWhiteSpaceTextNode(node) ||
+        node === expectedPre ||
+        node === expectedMacro
+      ) {
+        return visit.CONTINUE;
+      }
+
+      extraneousNode = node;
+      return visit.EXIT;
+    }
+  );
+  if (extraneousNode !== null) {
+    logger.fail(
+      extraneousNode,
+      "No other elements allowed in formal syntax",
+      "syntax-only"
+    );
+    return null;
+  }
+
+  return heading;
+}
+
+function isWhiteSpaceTextNode(node) {
+  return node.type === "text" && !/\S/.test(node.value);
+}
 
 module.exports = handleDataFormalSyntax;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
@@ -1,4 +1,4 @@
-const { isMacro, sliceSection } = require("./utils");
+const { isMacro, isWhiteSpaceTextNode, sliceSection } = require("./utils");
 const { select } = require("hast-util-select");
 const visit = require("unist-util-visit");
 
@@ -70,10 +70,6 @@ function handleDataFormalSyntax(tree, logger) {
   }
 
   return heading;
-}
-
-function isWhiteSpaceTextNode(node) {
-  return node.type === "text" && !/\S/.test(node.value);
 }
 
 module.exports = handleDataFormalSyntax;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
@@ -1,0 +1,3 @@
+function handleDataFormalSyntax(tree, logger) {}
+
+module.exports = handleDataFormalSyntax;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
@@ -6,7 +6,6 @@ function handleDataFormalSyntax(tree, logger) {
   const id = "Formal_syntax";
   const body = select(`body`, tree);
   const heading = select(`h2#${id}`, body);
-  const section = sliceSection(heading, body);
 
   if (heading === null) {
     logger.expected(body, `h2#${id}`, "expected-heading");
@@ -14,6 +13,7 @@ function handleDataFormalSyntax(tree, logger) {
   }
 
   // Section must contain pre.syntaxbox
+  const section = sliceSection(heading, body);
   const expectedSyntaxBox = select("pre.syntaxbox", section);
   if (expectedSyntaxBox === null) {
     logger.expected(tree, section, "expected-pre.syntaxbox");

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -4,6 +4,7 @@ const handleDataSpecifications = require("./data-specifications");
 const handleDataExamples = require("./data-examples");
 const handleDataInteractiveExample = require("./data-interactive-example");
 const handleDataBrowserCompatibility = require("./data-browser-compatibility");
+const handleDataFormalSyntax = require("./data-formal-syntax");
 const handleProseShortDescription = require("./prose-short-description");
 const handleDataConstructor = require("./data-constructor");
 const classMembers = require("./data-class-members");
@@ -29,6 +30,7 @@ const ingredientHandlers = {
   "data.constructor": handleDataConstructor,
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
   "data.examples": handleDataExamples,
+  "data.formal_syntax": handleDataFormalSyntax,
   "data.instance_methods?": classMembers.handleDataInstanceMethods,
   "data.instance_properties?": classMembers.handleDataInstanceProperties,
   "data.interactive_example?": handleDataInteractiveExample,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -1,13 +1,13 @@
 const { select } = require("hast-util-select");
 
-const handleDataSpecifications = require("./data-specifications");
-const handleDataExamples = require("./data-examples");
-const handleDataInteractiveExample = require("./data-interactive-example");
-const handleDataBrowserCompatibility = require("./data-browser-compatibility");
-const handleDataFormalSyntax = require("./data-formal-syntax");
-const handleProseShortDescription = require("./prose-short-description");
-const handleDataConstructor = require("./data-constructor");
 const classMembers = require("./data-class-members");
+const handleDataBrowserCompatibility = require("./data-browser-compatibility");
+const handleDataConstructor = require("./data-constructor");
+const handleDataExamples = require("./data-examples");
+const handleDataFormalSyntax = require("./data-formal-syntax");
+const handleDataInteractiveExample = require("./data-interactive-example");
+const handleDataSpecifications = require("./data-specifications");
+const handleProseShortDescription = require("./prose-short-description");
 
 /**
  * Functions to check for recipe ingredients in Kuma page sources.
@@ -27,8 +27,8 @@ const classMembers = require("./data-class-members");
  */
 const ingredientHandlers = {
   "data.browser_compatibility": handleDataBrowserCompatibility,
-  "data.constructor": handleDataConstructor,
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
+  "data.constructor": handleDataConstructor,
   "data.examples": handleDataExamples,
   "data.formal_syntax": handleDataFormalSyntax,
   "data.instance_methods?": classMembers.handleDataInstanceMethods,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
@@ -79,6 +79,17 @@ function isNewlineOnlyTextNode(node) {
   return node.type === "text" && node.value.match(/^\n*$/);
 }
 
+/**
+ * Check if a node's type is `"text"` and that contains only white space
+ * characters.
+ *
+ * @param {Object} node - An unist node
+ * @returns {Boolean} `true` for white space, `false` for anything else
+ */
+function isWhiteSpaceTextNode(node) {
+  return node.type === "text" && !/\S/.test(node.value);
+}
+
 function Logger(file, source, recipeName, ingredient) {
   return {
     expected: function (node, name, id) {
@@ -97,9 +108,10 @@ function Logger(file, source, recipeName, ingredient) {
 }
 
 module.exports = {
-  sliceSection,
-  sliceBetween,
   isMacro,
   isNewlineOnlyTextNode,
+  isWhiteSpaceTextNode,
   Logger,
+  sliceBetween,
+  sliceSection,
 };

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -5,10 +5,6 @@ const {
 } = require("./framework/utils");
 
 describe("data.formal_syntax", () => {
-  /*
-  TODO: update the specification for the formal syntax
-  */
-
   const ingredientName = "data.formal_syntax";
   const recipe = { body: [ingredientName] };
 

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -20,9 +20,7 @@ describe("data.formal_syntax", () => {
   test("missing h2", () => {
     const file = process("", recipe);
 
-    expect(file.messages.length).toBeGreaterThan(0);
     expect(file).hasMessageWithId(/data.formal_syntax\/expected-heading/);
-
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -31,9 +29,7 @@ describe("data.formal_syntax", () => {
                         {{ csssyntax("display") }}`;
     const file = process(missingPre, recipe);
 
-    expect(file.messages.length).toBeGreaterThan(0);
     expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre.syntaxbox/);
-
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -42,9 +38,7 @@ describe("data.formal_syntax", () => {
                           <pre>{{ csssyntax("display") }}</pre>`;
     const file = process(missingClass, recipe);
 
-    expect(file.messages.length).toBeGreaterThan(1);
     expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre.syntaxbox/);
-
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -53,9 +47,7 @@ describe("data.formal_syntax", () => {
                           <pre class="syntaxbox notranslate"></pre>`;
     const file = process(missingMacro, recipe);
 
-    expect(file.messages.length).toBeGreaterThan(0);
     expect(file).hasMessageWithId(/data.formal_syntax\/expected-macro/);
-
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -65,9 +57,7 @@ describe("data.formal_syntax", () => {
                                 <p>Some notes about this that don't belong here.</p>`;
     const file = process(extraneousElements, recipe);
 
-    expect(file.messages.length).toBeGreaterThan(0);
     expect(file).hasMessageWithId(/data.formal_syntax\/syntax-only/);
-
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 });

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -17,7 +17,7 @@ describe("data.formal_syntax", () => {
                  <pre class="syntaxbox notranslate">{{ csssyntax("display") }}</pre>`;
     const file = process(valid, recipe);
 
-    expect(file.messages).toStrictEqual([]);
+    expect(file).not.hasMessageWithId(ingredientName);
     expectPositionElement(file.data.ingredients[0], ingredientName, "h2");
   });
 

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -1,0 +1,49 @@
+const {
+  process,
+  expectPositionElement,
+  expectNullPosition,
+} = require("./framework/utils");
+
+describe("data.formal_syntax", () => {
+  /*
+  TODO: update the specification for the formal syntax
+  */
+
+  const ingredientName = "data.formal_syntax";
+  const recipe = { body: [ingredientName] };
+
+  test("valid", () => {
+    const valid = `<h2 id="Formal_syntax">Formal syntax</h2>
+                 <pre class="syntaxbox notranslate">{{ csssyntax("display") }}</pre>`;
+    const file = process(valid, recipe);
+
+    expect(file.messages).toStrictEqual([]);
+    expectPositionElement(file.data.ingredients[0], ingredientName, "h2");
+  });
+
+  test.skip("missing h2", () => {
+    const file = process("", recipe);
+
+    expect(file.messages.length).toBeGreaterThan(0);
+    expect(file).hasMessageWithId(/data.formal_syntax\/expected-heading/);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test.skip("missing pre", () => {
+    const missingPre = `<h2 id="Formal_syntax">Formal syntax</h2>
+                   {{ csssyntax("display") }}`;
+    const file = process(missingPre, recipe);
+
+    expect(file.messages.length).toBeGreaterThan(0);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test.skip("missing macro", () => {
+    const missingMacro = `<h2 id="Formal_syntax">Formal syntax</h2>
+                          <h2 id="Next_heading>Next heading</h2>`;
+    const file = process(missingMacro, recipe);
+
+    expect(file.messages.length).toBeGreaterThan(0);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+});

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -14,7 +14,7 @@ describe("data.formal_syntax", () => {
 
   test("valid", () => {
     const valid = `<h2 id="Formal_syntax">Formal syntax</h2>
-                 <pre class="syntaxbox notranslate">{{ csssyntax("display") }}</pre>`;
+                   <pre class="syntaxbox notranslate">{{ csssyntax("display") }}</pre>`;
     const file = process(valid, recipe);
 
     expect(file).not.hasMessageWithId(ingredientName);
@@ -30,9 +30,9 @@ describe("data.formal_syntax", () => {
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
-  test.skip("missing pre", () => {
+  test("missing pre", () => {
     const missingPre = `<h2 id="Formal_syntax">Formal syntax</h2>
-                   {{ csssyntax("display") }}`;
+                        {{ csssyntax("display") }}`;
     const file = process(missingPre, recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);
@@ -41,9 +41,9 @@ describe("data.formal_syntax", () => {
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
-  test.skip("missing macro", () => {
+  test("missing macro", () => {
     const missingMacro = `<h2 id="Formal_syntax">Formal syntax</h2>
-                          <h2 id="Next_heading>Next heading</h2>`;
+                          <pre class="syntaxbox notranslate"></pre>`;
     const file = process(missingMacro, recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -21,7 +21,7 @@ describe("data.formal_syntax", () => {
     expectPositionElement(file.data.ingredients[0], ingredientName, "h2");
   });
 
-  test.skip("missing h2", () => {
+  test("missing h2", () => {
     const file = process("", recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -26,6 +26,7 @@ describe("data.formal_syntax", () => {
 
     expect(file.messages.length).toBeGreaterThan(0);
     expect(file).hasMessageWithId(/data.formal_syntax\/expected-heading/);
+
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -35,6 +36,8 @@ describe("data.formal_syntax", () => {
     const file = process(missingPre, recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);
+    expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre/);
+
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 
@@ -44,6 +47,8 @@ describe("data.formal_syntax", () => {
     const file = process(missingMacro, recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);
+    expect(file).hasMessageWithId(/data.formal_syntax\/expected-macro/);
+
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 });

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -39,7 +39,7 @@ describe("data.formal_syntax", () => {
 
   test("missing syntaxbox class", () => {
     const missingClass = `<h2 id="Formal_syntax">Formal syntax</h2>
-                   <pre>{{ csssyntax("display") }}</pre>`;
+                          <pre>{{ csssyntax("display") }}</pre>`;
     const file = process(missingClass, recipe);
 
     expect(file.messages.length).toBeGreaterThan(1);

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -51,4 +51,16 @@ describe("data.formal_syntax", () => {
 
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
+
+  test("unexpected elements", () => {
+    const extraneousElements = `<h2 id="Formal_syntax">Formal syntax</h2>
+                                <pre class="syntaxbox notranslate">{{ csssyntax("display") }}</pre>
+                                <p>Some notes about this that don't belong here.</p>`;
+    const file = process(extraneousElements, recipe);
+
+    expect(file.messages.length).toBeGreaterThan(0);
+    expect(file).hasMessageWithId(/data.formal_syntax\/syntax-only/);
+
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
 });

--- a/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.formal_syntax.test.js
@@ -36,7 +36,18 @@ describe("data.formal_syntax", () => {
     const file = process(missingPre, recipe);
 
     expect(file.messages.length).toBeGreaterThan(0);
-    expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre/);
+    expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre.syntaxbox/);
+
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("missing syntaxbox class", () => {
+    const missingClass = `<h2 id="Formal_syntax">Formal syntax</h2>
+                   <pre>{{ csssyntax("display") }}</pre>`;
+    const file = process(missingClass, recipe);
+
+    expect(file.messages.length).toBeGreaterThan(1);
+    expect(file).hasMessageWithId(/data.formal_syntax\/expected-pre.syntaxbox/);
 
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });


### PR DESCRIPTION
This PR adds an ingredient handler for `data.formal_syntax`. It also amends the spec for the handler slightly, to accommodate the obligatory `<pre class="syntaxbox">` tag required for the `CSSSyntax` macro (see https://github.com/mdn/stumptown-content/issues/458#issuecomment-639716348).

I also sorted the ingredient handlers in `ingredient-handlers/index.js` while I was here.

Fixes #458.