### PR TITLE
Add placeholder ingredient handlers for data.constituent_properties and data.formal_definition

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -27,9 +27,13 @@ const handleProseShortDescription = require("./prose-short-description");
  */
 const ingredientHandlers = {
   "data.browser_compatibility": handleDataBrowserCompatibility,
+  "data.constituent_properties": requireTopLevelHeading(
+    "Constituent properties"
+  ),
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
   "data.constructor": handleDataConstructor,
   "data.examples": handleDataExamples,
+  "data.formal_definition": requireTopLevelHeading("Formal definition"),
   "data.formal_syntax": handleDataFormalSyntax,
   "data.instance_methods?": classMembers.handleDataInstanceMethods,
   "data.instance_properties?": classMembers.handleDataInstanceProperties,


### PR DESCRIPTION
As discussed in the call today, this PR partly implements `data.constituent_properties` and `data.formal_definition`, to help with identifying failing pages. They're not complete implementations for #427 and #457; I plan to do so fully in follow-up PRs.