### PR TITLE
Use correct IDs for placeholder formal syntax and constituent properties

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -28,12 +28,12 @@ const handleProseShortDescription = require("./prose-short-description");
 const ingredientHandlers = {
   "data.browser_compatibility": handleDataBrowserCompatibility,
   "data.constituent_properties": requireTopLevelHeading(
-    "Constituent properties"
+    "Constituent_properties"
   ),
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
   "data.constructor": handleDataConstructor,
   "data.examples": handleDataExamples,
-  "data.formal_definition": requireTopLevelHeading("Formal definition"),
+  "data.formal_definition": requireTopLevelHeading("Formal_definition"),
   "data.formal_syntax": handleDataFormalSyntax,
   "data.instance_methods?": classMembers.handleDataInstanceMethods,
   "data.instance_properties?": classMembers.handleDataInstanceProperties,


### PR DESCRIPTION
In #478, I accidentally used spaces instead of underscores in the IDs for `h2#Formal_syntax` and `h2#Constituent_properties`. This is a small fix ahead of #480 and the eventual PR for `data.constituent_properties`.