### PR TITLE
Add recipe for CSS selectors

### DIFF
--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -66,6 +66,7 @@ prose ingredients:
 data ingredients:
 
 - data.browser_compatibility
+- data.permitted_properties?
 - data.constituent_properties
 - data.constructor
 - data.constructor_properties?
@@ -115,6 +116,16 @@ Data ingredients typically impose more detailed requirements on pages than prose
 #### data.browser_compatibility
 
 To satisfy this ingredient a page must have a section demarcated by `H2#Browser_compatibility`. It must contain a call to the `{{Compat}}` macro.
+
+#### data.permitted_properties?
+
+This is an optional ingredient. It is present if the page has a section demarcated by `H2#Permitted_properties`. The section must contain only the following elements:
+
+1. A `<p>` element consisting of the text:
+
+   > Rules whose selectors include this element may only use the following CSS properties:
+
+2. An unordered list (a `<ul>` element) of two or more CSS property names. Each property name must be in the form `<li><a><code>p</code></a></li>`, where _p_ is the name of a property. The `<li>` elements must be in alphabetical order.
 
 #### data.constituent_properties
 

--- a/recipes/css-selector.yaml
+++ b/recipes/css-selector.yaml
@@ -6,7 +6,7 @@ body:
   - prose.short_description
   - prose.syntax
   - prose.description?
-  - prose.allowable_properties?
+  - prose.applicable_properties?
   - prose.accessibility_concerns?
   - prose.*
   - data.examples

--- a/recipes/css-selector.yaml
+++ b/recipes/css-selector.yaml
@@ -1,0 +1,15 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.syntax
+  - prose.description?
+  - prose.allowable_properties?
+  - prose.accessibility_concerns?
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/css-selector.yaml
+++ b/recipes/css-selector.yaml
@@ -6,7 +6,7 @@ body:
   - prose.short_description
   - prose.syntax
   - prose.description?
-  - prose.applicable_properties?
+  - data.permitted_properties?
   - prose.accessibility_concerns?
   - prose.*
   - data.examples

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -8,6 +8,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-selector"),
+    conditions: {
+      tags: ["CSS", "Selector"],
+    },
+  },
+  {
     recipePath: recipe("css-shorthand-property"),
     conditions: {
       tags: ["recipe:css-shorthand-property"],


### PR DESCRIPTION
This PR adds a recipe for CSS selectors, following the discussion in https://github.com/mdn/stumptown-content/issues/440.

I've omitted `data.formal_syntax` but included an optional `prose.applicable_properties`. This section is currently only included in the following pages:

https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::cue
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::cue-region
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::first-letter
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::first-line
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::grammar-error
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::marker
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::selection
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/::spelling-error

(where it's named "Allowed properties" but I like "Applicable properties" better)

...out of about 70 non-prefixed selectors. However, it seems like a legitimately consistent and useful thing to want to include, and in future we might perhaps want to add it to more pages. We should probably structure it as a `data.` ingredient in future, as a list of property names. Or maybe we should do that now?

I also used generic tags `["CSS", "Selector"]` instead of a custom tag like `["recipe:css-selector"]` as we have for properties. I'm not sure if that's a good idea or not. But I'm still a little uncomfortable with these custom tags for some reason, and the reasoning that pushed us there with properties doesn't seem to apply here.


