### PR TITLE
Add handler for data.constituent_properties

### DIFF
--- a/project-docs/linter-spec.md
+++ b/project-docs/linter-spec.md
@@ -117,10 +117,13 @@ To satisfy this ingredient a page must have a section demarcated by `H2#Browser_
 
 #### data.constituent_properties
 
-To satisfy this ingredient a page must have a section demarcated by `H2#Constituent_properties`. This section must contain the following elements, in the order given below:
+To satisfy this ingredient a page must have a section demarcated by `H2#Constituent_properties`. The section must contain only the following elements:
 
-- a `<p>` element containing the following text: "This property is a shorthand for the following CSS properties:"
-- a `<ul>` element containing two or more `<li>` elements, each of which contains a single `<a><code>` element.
+1. A `<p>` element consisting of the text:
+
+   > This property is a shorthand for the following CSS properties:
+
+2. An unordered list (a `<ul>` element) of two or more CSS property names. Each property name must be in the form `<li><a><code>p</code></a></li>`, where _p_ is the name of a property. The `<li>` elements must be in alphabetical order.
 
 #### data.constructor
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
@@ -54,6 +54,16 @@ const handleDataConstituentProperties = sectionHandler(
       }
     }
 
+    const unsorted = findUnsortedProperty(lis);
+    if (unsorted !== null) {
+      logger.fail(
+        unsorted,
+        "Constituent property list is not in alphabetical order",
+        "expected-alpha-sorted-properties"
+      );
+      return null;
+    }
+
     let unexpectedNode = findUnexpectedNode(
       section,
       [heading, expectedIntroTextP, ...lis],
@@ -138,6 +148,25 @@ function isWellFormedProperty(node) {
     }
   );
   return ok;
+}
+
+/**
+ * From an array of well-formed property list entries, get the first list item
+ * out of order, or return `null`.
+ *
+ * @param {Array<Object>} lis - An array of LI nodes
+ * @returns {Object|null} - A node that's out of order or `null`
+ */
+function findUnsortedProperty(lis) {
+  let previous = "";
+  for (const li of lis) {
+    const literalText = li.children[0].children[0].children[0].value;
+    if (previous.localeCompare(literalText) > 0) {
+      return li;
+    }
+    previous = literalText;
+  }
+  return null;
 }
 
 module.exports = handleDataConstituentProperties;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
@@ -1,0 +1,143 @@
+const visit = require("unist-util-visit");
+
+const {
+  findUnexpectedNode,
+  isWhiteSpaceTextNode,
+  sectionHandler,
+  sliceBetween,
+} = require("./utils");
+
+const handleDataConstituentProperties = sectionHandler(
+  "Constituent_properties",
+  (section, logger) => {
+    const heading = section.children[0];
+    const expectedIntroTextP = findIntroTextP(section);
+
+    if (expectedIntroTextP === null) {
+      logger.expected(
+        section,
+        '"This property is a shorthand for the following CSS properties:" paragraph',
+        "expected-intro-p"
+      );
+      return null;
+    }
+
+    const expectedUl = findNextUl(expectedIntroTextP, section);
+    if (expectedUl === null) {
+      logger.expected(
+        expectedIntroTextP,
+        "constituent property list UL after intro text",
+        "expected-ul"
+      );
+      return null;
+    }
+
+    const lis = findLis(expectedUl);
+
+    if (lis.length < 2) {
+      logger.expected(
+        expectedUl,
+        "two or more LIs in constituent property list",
+        "expected-more-lis"
+      );
+      return null;
+    }
+
+    for (const li of lis) {
+      if (!isWellFormedProperty(li)) {
+        logger.fail(
+          li,
+          "Constituent property list entry is malformed",
+          "expected-li-a-code"
+        );
+        return null;
+      }
+    }
+
+    let unexpectedNode = findUnexpectedNode(
+      section,
+      [heading, expectedIntroTextP, ...lis],
+      [expectedUl]
+    );
+    if (unexpectedNode !== null) {
+      logger.fail(
+        unexpectedNode,
+        "No other elements allowed in constituent properties",
+        "unexpected-content"
+      );
+      return null;
+    }
+
+    return heading;
+  }
+);
+
+function findIntroTextP(section) {
+  return (
+    section.children.find((node) => {
+      return (
+        node.tagName === "p" &&
+        node.children.length === 1 &&
+        node.children[0].value.trim() ===
+          "This property is a shorthand for the following CSS properties:"
+      );
+    }) || null
+  );
+}
+
+function findNextUl(startNode, tree) {
+  let ul = null;
+  visit(
+    sliceBetween(startNode, () => {}, tree),
+    (node) => node.tagName === "ul",
+    (node) => {
+      ul = node;
+      return visit.EXIT;
+    }
+  );
+  return ul;
+}
+
+function findLis(ul) {
+  let lis = [];
+
+  if (ul.children) {
+    lis = ul.children.filter((child) => child.tagName === "li");
+  }
+
+  return lis;
+}
+
+/**
+ * Check if `node` is in the form `<li><a><code>text</code></a></li>`, ignoring
+ * white space.
+ *
+ * @param {Object} node - A hast node
+ * @returns {Boolean} - `true` or `false`
+ */
+function isWellFormedProperty(node) {
+  const expectations = [
+    (node) => node.tagName === "li" && node.children,
+    (node) => node.tagName === "a" && node.children,
+    (node) => node.tagName === "code" && node.children,
+    (node) => node.type === "text" && !node.children,
+  ];
+
+  let count = 0;
+  let ok = true;
+  visit(
+    node,
+    (node) => !isWhiteSpaceTextNode(node),
+    (node) => {
+      const check = expectations[count];
+      if (!check || !check(node)) {
+        ok = false;
+        return visit.EXIT;
+      }
+      count = count + 1;
+    }
+  );
+  return ok;
+}
+
+module.exports = handleDataConstituentProperties;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/index.js
@@ -2,6 +2,7 @@ const { select } = require("hast-util-select");
 
 const classMembers = require("./data-class-members");
 const handleDataBrowserCompatibility = require("./data-browser-compatibility");
+const handleDataConstituentProperties = require("./data-constituent-properties");
 const handleDataConstructor = require("./data-constructor");
 const handleDataExamples = require("./data-examples");
 const handleDataFormalDefinition = require("./data-formal-definition");
@@ -28,9 +29,7 @@ const handleProseShortDescription = require("./prose-short-description");
  */
 const ingredientHandlers = {
   "data.browser_compatibility": handleDataBrowserCompatibility,
-  "data.constituent_properties": requireTopLevelHeading(
-    "Constituent_properties"
-  ),
+  "data.constituent_properties": handleDataConstituentProperties,
   "data.constructor_properties?": classMembers.handleDataConstructorProperties,
   "data.constructor": handleDataConstructor,
   "data.examples": handleDataExamples,

--- a/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
@@ -14,6 +14,7 @@ describe("data.constituent_properties", () => {
     missingLis: /data.constituent_properties\/expected-more-lis/,
     malformedLi: /data.constituent_properties\/expected-li-a-code/,
     hasExtraContent: /data.constituent_properties\/unexpected-content/,
+    outOfOrder: /data.constituent_properties\/expected-alpha-sorted-properties/,
   };
 
   test("valid", () => {
@@ -102,6 +103,20 @@ describe("data.constituent_properties", () => {
     const file = process(insufficientListItems, recipe);
 
     expect(file).hasMessageWithId(errorIds.missingLis);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("out-of-order-list-items", () => {
+    const outOfOrder = `<h2 id="Constituent_properties">Constituent properties</h2>
+                        <p>This property is a shorthand for the following CSS properties:</p>
+                        <ul>
+                          <li><a><code>property-a</code></a></li>
+                          <li><a><code>property-x</code></a></li>
+                          <li><a><code>property-b</code></a></li>
+                        </ul>`;
+    const file = process(outOfOrder, recipe);
+
+    expect(file).hasMessageWithId(errorIds.outOfOrder);
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 

--- a/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
@@ -1,0 +1,95 @@
+const {
+  process,
+  expectPositionElement,
+  expectNullPosition,
+} = require("./framework/utils");
+
+describe("data.constituent_properties", () => {
+  const ingredientName = "data.constituent_properties";
+  const recipe = { body: [ingredientName] };
+  const errorIds = {
+    missingHeading: /data.constituent_properties\/expected-heading/,
+    missingText: /data.constituent_properties\/expected-intro-p/,
+    missingUl: /data.constituent_properties\/expected-ul/,
+    missingLis: /data.constituent_properties\/expected-li-a-code/,
+    hasExtraContent: /data.constituent_properties\/unexpected-content/,
+  };
+
+  test("valid", () => {
+    const valid = `<h2 id="Constituent_properties">Constituent properties</h2>
+                   <p>This property is a shorthand for the following CSS properties:</p>
+                   <ul>
+                    <li><a><code>property-one</code></a></li>
+                    <li><a><code>property-two</code></a></li>
+                    <li><a><code>property-three</code></a></li>
+                   </ul>`;
+    const file = process(valid, recipe);
+
+    expect(file).not.hasMessageWithId(ingredientName);
+    expectPositionElement(file.data.ingredients[0], ingredientName, "h2");
+  });
+
+  test("missing-h2", () => {
+    const file = process("", recipe);
+
+    expect(file).hasMessageWithId(errorIds.missingHeading);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("missing-text", () => {
+    const missingText = `<h2 id="Constituent_properties">Constituent properties</h2>`;
+    const file = process(missingText, recipe);
+
+    expect(file).hasMessageWithId(errorIds.missingText);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("missing-list", () => {
+    const missingList = `<h2 id="Constituent_properties">Constituent properties</h2>
+                         <p>This property is a shorthand for the following CSS properties:</p>`;
+    const file = process(missingList, recipe);
+
+    expect(file).hasMessageWithId(errorIds.missingUl);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("missing-list-items", () => {
+    const missingListItems = `<h2 id="Constituent_properties">Constituent properties</h2>
+                              <p>This property is a shorthand for the following CSS properties:</p>
+                              <ul>
+                                <li><a><code>property-one</code></a></li>
+                                <li><a><code>property-two</code></a></li>
+                                <li><a><code>property-three</code></a></li>
+                              </ul>`;
+    const file = process(missingListItems, recipe);
+
+    expect(file).hasMessageWithId(errorIds.missingLis);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("insufficient-list-items", () => {
+    const insufficientListItems = `<h2 id="Constituent_properties">Constituent properties</h2>
+                                   <p>This property is a shorthand for the following CSS properties:</p>
+                                   <ul>
+                                     <li><a><code>property-one</code></a></li>
+                                   </ul>`;
+    const file = process(insufficientListItems, recipe);
+
+    expect(file).hasMessageWithId(errorIds.missingLis);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("unexpected-content", () => {
+    const extraneousContent = `<h2 id="Constituent_properties">Constituent properties</h2>
+                               <p>This property is a shorthand for the following CSS properties:</p>
+                               <ul>
+                                 <li><a><code>property-one</code></a></li>
+                                 <li><a><code>property-two</code></a></li>
+                               </ul>
+                               <p>This paragraph is forbidden.</p>`;
+    const file = process(extraneousContent, recipe);
+
+    expect(file).hasMessageWithId(errorIds.hasExtraContent);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+});

--- a/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
@@ -21,9 +21,9 @@ describe("data.constituent_properties", () => {
     const valid = `<h2 id="Constituent_properties">Constituent properties</h2>
                    <p>This property is a shorthand for the following CSS properties:</p>
                    <ul>
-                    <li><a><code>property-one</code></a></li>
-                    <li><a><code>property-two</code></a></li>
-                    <li><a><code>property-three</code></a></li>
+                    <li><a><code>property-a</code></a></li>
+                    <li><a><code>property-b</code></a></li>
+                    <li><a><code>property-c</code></a></li>
                    </ul>`;
     const file = process(valid, recipe);
 

--- a/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
@@ -8,12 +8,12 @@ describe("data.constituent_properties", () => {
   const ingredientName = "data.constituent_properties";
   const recipe = { body: [ingredientName] };
   const errorIds = {
+    hasExtraContent: /data.constituent_properties\/unexpected-content/,
+    malformedLi: /data.constituent_properties\/expected-li-a-code/,
     missingHeading: /data.constituent_properties\/expected-heading/,
+    missingLis: /data.constituent_properties\/expected-more-lis/,
     missingText: /data.constituent_properties\/expected-intro-p/,
     missingUl: /data.constituent_properties\/expected-ul/,
-    missingLis: /data.constituent_properties\/expected-more-lis/,
-    malformedLi: /data.constituent_properties\/expected-li-a-code/,
-    hasExtraContent: /data.constituent_properties\/unexpected-content/,
     outOfOrder: /data.constituent_properties\/expected-alpha-sorted-properties/,
   };
 

--- a/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.constituent_properties.test.js
@@ -1,7 +1,7 @@
 const {
-  process,
-  expectPositionElement,
   expectNullPosition,
+  expectPositionElement,
+  process,
 } = require("./framework/utils");
 
 describe("data.constituent_properties", () => {
@@ -11,7 +11,8 @@ describe("data.constituent_properties", () => {
     missingHeading: /data.constituent_properties\/expected-heading/,
     missingText: /data.constituent_properties\/expected-intro-p/,
     missingUl: /data.constituent_properties\/expected-ul/,
-    missingLis: /data.constituent_properties\/expected-li-a-code/,
+    missingLis: /data.constituent_properties\/expected-more-lis/,
+    malformedLi: /data.constituent_properties\/expected-li-a-code/,
     hasExtraContent: /data.constituent_properties\/unexpected-content/,
   };
 
@@ -57,13 +58,38 @@ describe("data.constituent_properties", () => {
     const missingListItems = `<h2 id="Constituent_properties">Constituent properties</h2>
                               <p>This property is a shorthand for the following CSS properties:</p>
                               <ul>
-                                <li><a><code>property-one</code></a></li>
-                                <li><a><code>property-two</code></a></li>
-                                <li><a><code>property-three</code></a></li>
                               </ul>`;
     const file = process(missingListItems, recipe);
 
     expect(file).hasMessageWithId(errorIds.missingLis);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("malformed-list-items-incomplete", () => {
+    const malformedListItems = `<h2 id="Constituent_properties">Constituent properties</h2>
+                                <p>This property is a shorthand for the following CSS properties:</p>
+                                <ul>
+                                  <li><a>property-one</a></li>
+                                  <li><a><code>property-two</code></a></li>
+                                  <li><a><code>property-three</code></a></li>
+                                </ul>`;
+    const file = process(malformedListItems, recipe);
+
+    expect(file).hasMessageWithId(errorIds.malformedLi);
+    expectNullPosition(file.data.ingredients[0], ingredientName);
+  });
+
+  test("malformed-list-items-extra", () => {
+    const malformedListItems = `<h2 id="Constituent_properties">Constituent properties</h2>
+                                <p>This property is a shorthand for the following CSS properties:</p>
+                                <ul>
+                                  <li><a><code>property-one</code></a><br/></li>
+                                  <li><a><code>property-two</code></a></li>
+                                  <li><a><code>property-three</code></a></li>
+                                </ul>`;
+    const file = process(malformedListItems, recipe);
+
+    expect(file).hasMessageWithId(errorIds.malformedLi);
     expectNullPosition(file.data.ingredients[0], ingredientName);
   });
 


### PR DESCRIPTION
This PR implements the `data.constituent_properties` ingredient. It expects a section with fixed intro text, followed by an unordered list of two or more `<code>`-formatted links.

Fixes #427 