### PR TITLE
Add recipes for CSS at-rules

### DIFF
--- a/recipes/css-at-rule-descriptor.yaml
+++ b/recipes/css-at-rule-descriptor.yaml
@@ -1,0 +1,16 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.syntax
+  - prose.description?
+  - prose.accessibility_concerns?
+  - prose.*
+  - data.formal_definition
+  - data.formal_syntax
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/css-at-rule.yaml
+++ b/recipes/css-at-rule.yaml
@@ -1,0 +1,15 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.syntax
+  - prose.description?
+  - prose.accessibility_concerns?
+  - prose.*
+  - data.formal_syntax
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/recipes/css-media-feature.yaml
+++ b/recipes/css-media-feature.yaml
@@ -1,0 +1,12 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.syntax
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -2,6 +2,12 @@ const path = require("path");
 
 const signatures = [
   {
+    recipePath: recipe("css-at-rule"),
+    conditions: {
+      tags: ["CSS", "At-rule"],
+    },
+  },
+  {
     recipePath: recipe("css-property"),
     conditions: {
       tags: ["recipe:css-property"],

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -14,6 +14,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-media-feature"),
+    conditions: {
+      tags: ["CSS", "Media feature"],
+    },
+  },
+  {
     recipePath: recipe("css-property"),
     conditions: {
       tags: ["recipe:css-property"],

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -8,6 +8,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-at-rule-descriptor"),
+    conditions: {
+      tags: ["CSS", "At-rule descriptor"],
+    },
+  },
+  {
     recipePath: recipe("css-property"),
     conditions: {
       tags: ["recipe:css-property"],


### PR DESCRIPTION
This PR adds three new recipes for the three page types associated with at-rules, as described in https://github.com/mdn/stumptown-content/issues/466#issuecomment-648453083.

Note that there are no new ingredients to implement here.

## CSS at-rules

For reference, these are the at-rules:

* [`@charset`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@charset)
* [`@counter-style`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style)
* [`@document`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@document)
* [`@font-face`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face)
* [`@font-feature-values`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-feature-values)
* [`@import`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@import)
* [`@keyframes`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@keyframes)
* [`@media`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media)
* [`@namespace`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@namespace)
* [`@page`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@page)
* [`@styleset`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@styleset)
* [`@supports`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@supports)
* [`@viewport`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport)

These things get a recipe like:

```yaml
data:
  - title
  - short_title?
  - mdn_url
body:
  - prose.short_description
  - prose.syntax
  - prose.description?
  - prose.accessibility_concerns?
  - prose.*
  - data.formal_syntax
  - data.examples
  - data.specifications
  - data.browser_compatibility
  - prose.see_also
```

This is a lot like CSS properties, except there's no interactive example and no "Formal definition". All the existing at-rule pages have a "Formal syntax" section that uses `{{csssyntax}}`, so it seems reasonable to include that ingredient here. A few have an "Accessibility concerns" section. Most do not have an explicit "description" but they do often have a long prose-y intro that could be repurposed into "Description".

## CSS at-rule descriptors

For reference, these are the at-rule descriptors:

* `@counter-style` (10)
    * [`additive-symbols`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/additive-symbols)
    * [`fallback`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/fallback)
    * [`negative`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/negative)
    * [`pad`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/pad)
    * [`prefix`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/prefix)
    * [`range`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/range)
    * [`speak-as`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/speak-as)
    * [`suffix`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/suffix)
    * [`symbols`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/symbols)
    * [`system`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@counter-style/system)
* `@font-face` (8)
    * [`font-display`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)
    * [`font-family`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-family)
    * [`font-stretch`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-stretch)
    * [`font-style`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-style)
    * [`font-variation-settings`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-variation-settings)
    * [`font-weight`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight)
    * [`src`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src)
    * [`unicode-range`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range)
* `@page` (3)
    * [`bleed`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@page/bleed)
    * [`marks`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@page/marks)
    * [`size`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@page/size)
* `@viewport` (12)
    * [`height`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/height)
    * [`max-height`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-height)
    * [`max-width`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-width)
    * [`max-zoom`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-zoom)
    * [`min-height`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/min-height)
    * [`min-width`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/min-width)
    * [`min-zoom`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/min-zoom)
    * [`orientation`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/orientation)
    * [`user-zoom`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/user-zoom)
    * [`viewport-fit`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/viewport-fit)
    * [`width`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/width)
    * [`zoom`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@viewport/zoom)

These get a recipe like:

```yaml
data:
  - title
  - short_title?
  - mdn_url
body:
  - prose.short_description
  - prose.syntax
  - prose.description?
  - prose.accessibility_concerns?
  - prose.*
  - data.formal_definition
  - data.formal_syntax
  - data.examples
  - data.specifications
  - data.browser_compatibility
  - prose.see_also
```

These are even more like CSS properties. They have "Formal definition", using `{{cssinfo}}`, as well as "Formal syntax" using `{{csssyntax}}`. They don't have interactive examples though.

## CSS media feature

For reference, these are the media features:

* [`-moz-device-pixel-ratio`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-device-pixel-ratio)
* [`-moz-mac-graphite-theme`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-mac-graphite-theme)
* [`-moz-maemo-classic`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-maemo-classic)
* [`-moz-os-version`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-os-version)
* [`-moz-scrollbar-end-backward`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-scrollbar-end-backward)
* [`-moz-scrollbar-end-forward`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-scrollbar-end-forward)
* [`-moz-scrollbar-start-backward`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-scrollbar-start-backward)
* [`-moz-scrollbar-start-forward`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-scrollbar-start-forward)
* [`-moz-scrollbar-thumb-proportional`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-scrollbar-thumb-proportional)
* [`-moz-touch-enabled`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-touch-enabled)
* [`-moz-windows-accent-color-in-titlebar`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-accent-color-in-titlebar)
* [`-moz-windows-classic`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-classic)
* [`-moz-windows-compositor`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-compositor)
* [`-moz-windows-default-theme`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-default-theme)
* [`-moz-windows-glass`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-glass)
* [`-moz-windows-theme`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-windows-theme)
* [`-ms-high-contrast`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-ms-high-contrast)
* [`-webkit-animation`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-animation)
* [`-webkit-device-pixel-ratio`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-device-pixel-ratio)
* [`-webkit-transform-2d`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-transform-2d)
* [`-webkit-transform-3d`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-transform-3d)
* [`-webkit-transition`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-transition)
* [`Index`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/Index)
* [`any-hover`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover)
* [`any-pointer`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/any-pointer)
* [`aspect-ratio`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/aspect-ratio)
* [`aural`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/aural)
* [`color`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/color)
* [`color-gamut`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/color-gamut)
* [`color-index`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/color-index)
* [`device-aspect-ratio`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/device-aspect-ratio)
* [`device-height`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/device-height)
* [`device-width`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/device-width)
* [`display-mode`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode)
* [`forced-colors`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
* [`grid`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/grid)
* [`height`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/height)
* [`hover`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/hover)
* [`inverted-colors`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors)
* [`light-level`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/light-level)
* [`monochrome`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/monochrome)
* [`orientation`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/orientation)
* [`overflow-block`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/overflow-block)
* [`overflow-inline`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/overflow-inline)
* [`pointer`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer)
* [`prefers-color-scheme`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
* [`prefers-contrast`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast)
* [`prefers-reduced-data`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-data)
* [`prefers-reduced-motion`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
* [`prefers-reduced-transparency`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency)
* [`resolution`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/resolution)
* [`scan`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/scan)
* [`scripting`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting)
* [`shape`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/shape)
* [`update`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/update-frequency)
* [`width`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/@media/width)

These get a really simple recipe:

```yaml
data:
  - title
  - short_title?
  - mdn_url
body:
  - prose.short_description
  - prose.syntax
  - prose.*
  - data.examples
  - data.specifications
  - data.browser_compatibility
  - prose.see_also
```

I think most notably these do not include `prose.description?`. We could always add it, but as far as I can see these pages don't currently use a description.

