### PR TITLE
Add recipe for CSS data types

### DIFF
--- a/recipes/css-data-type.yaml
+++ b/recipes/css-data-type.yaml
@@ -1,0 +1,15 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description?
+  - prose.accessibility_concerns?
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -14,6 +14,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-data-type"),
+    conditions: {
+      tags: ["CSS", "Data type"],
+    },
+  },
+  {
     recipePath: recipe("css-media-feature"),
     conditions: {
       tags: ["CSS", "Media feature"],


### PR DESCRIPTION
Fix for https://github.com/mdn/stumptown-content/issues/441 , and see the thread there for some reasoning about why this recipe looks the way it does. 

This PR adds a recipe for CSS data types.

It's just like the recipe for properties except with no "Formal definition" or "Formal syntax".