### PR TITLE
Add recipe for CSS functions

### DIFF
--- a/recipes/css-function.yaml
+++ b/recipes/css-function.yaml
@@ -1,0 +1,15 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - data.interactive_example?
+  - prose.syntax
+  - prose.description?
+  - prose.accessibility_concerns?
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -20,6 +20,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-function"),
+    conditions: {
+      tags: ["CSS", "Function"],
+    },
+  },
+  {
     recipePath: recipe("css-media-feature"),
     conditions: {
       tags: ["CSS", "Media feature"],


### PR DESCRIPTION
Fix for https://github.com/mdn/stumptown-content/issues/439.

This PR adds a recipe for CSS functions. I think the issues for CSS functions are the same as those for CSS types:

1) do we want to standardise/structure "Syntax" at this time?
2) should these types of page contain BCD at all?
3) if not, should we deal with removing BCD from these pages at the moment?

Given that for CSS types we answered ["no, no, no"](https://github.com/mdn/stumptown-content/issues/441) I think we should have the same answer for CSS functions, so this PR adds a recipe that's just the same. In particular:

* `prose.syntax` is an unstructured prose block, as for all the other page types
* `data.browser_compatibility` is included, even though we would prefer eventually not to include BCD in pages like this.