### PR TITLE
Refactor ingredient handlers for sections

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-browser-compatibility.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-browser-compatibility.js
@@ -1,4 +1,3 @@
-const { select } = require("hast-util-select");
 const visit = require("unist-util-visit");
 
 const utils = require("./utils.js");
@@ -6,31 +5,26 @@ const utils = require("./utils.js");
 /**
  * Handler for the `data.browser_compatibility` ingredient.
  */
-function handleDataBrowserCompatibility(tree, logger) {
-  const id = "Browser_compatibility";
-  const body = select(`body`, tree);
-  const heading = select(`h2#${id}`, body);
+const handleDataBrowserCompatibility = utils.sectionHandler(
+  "Browser_compatibility",
+  (section, logger) => {
+    let macroCount = 0;
+    visit(
+      section,
+      (node) => utils.isMacro(node, "Compat"),
+      () => {
+        macroCount += 1;
+      }
+    );
 
-  if (heading === null) {
-    logger.expected(body, `h2#${id}`, "expected-heading");
-    return null;
-  }
-
-  let macroCount = 0;
-  visit(
-    utils.sliceSection(heading, body),
-    (node) => utils.isMacro(node, "Compat"),
-    () => {
-      macroCount += 1;
+    if (macroCount !== 1) {
+      const heading = section.children[0];
+      logger.expected(heading, "Compat macro", "expected-macro");
+      return false;
     }
-  );
 
-  if (macroCount !== 1) {
-    logger.expected(body, `Compat macro`, "expected-macro");
-    return null;
+    return true;
   }
-
-  return heading;
-}
+);
 
 module.exports = handleDataBrowserCompatibility;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-class-members.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-class-members.js
@@ -1,39 +1,50 @@
 const checkLinkList = require("./link-list-checker.js");
+const { sectionHandler } = require("./utils");
 
 /**
  * Handler for the `data.constructor_properties` ingredient.
  */
-function handleDataConstructorProperties(tree, logger) {
-  return checkLinkList("Constructor_properties", tree, logger);
-}
+const handleDataConstructorProperties = sectionHandler(
+  "Constructor_properties",
+  checkLinkList,
+  true
+);
 
 /**
  * Handler for the `data.static_methods` ingredient.
  */
-function handleDataStaticMethods(tree, logger) {
-  return checkLinkList("Static_methods", tree, logger);
-}
+const handleDataStaticMethods = sectionHandler(
+  "Static_methods",
+  checkLinkList,
+  true
+);
 
 /**
  * Handler for the `data.static_properties` ingredient.
  */
-function handleDataStaticProperties(tree, logger) {
-  return checkLinkList("Static_properties", tree, logger);
-}
+const handleDataStaticProperties = sectionHandler(
+  "Static_properties",
+  checkLinkList,
+  true
+);
 
 /**
  * Handler for the `data.instance_methods` ingredient.
  */
-function handleDataInstanceMethods(tree, logger) {
-  return checkLinkList("Instance_methods", tree, logger);
-}
+const handleDataInstanceMethods = sectionHandler(
+  "Instance_methods",
+  checkLinkList,
+  true
+);
 
 /**
  * Handler for the `data.instance_properties` ingredient.
  */
-function handleDataInstanceProperties(tree, logger) {
-  return checkLinkList("Instance_properties", tree, logger);
-}
+const handleDataInstanceProperties = sectionHandler(
+  "Instance_properties",
+  checkLinkList,
+  true
+);
 
 module.exports = {
   handleDataConstructorProperties,

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constituent-properties.js
@@ -10,7 +10,6 @@ const {
 const handleDataConstituentProperties = sectionHandler(
   "Constituent_properties",
   (section, logger) => {
-    const heading = section.children[0];
     const expectedIntroTextP = findIntroTextP(section);
 
     if (expectedIntroTextP === null) {
@@ -66,7 +65,7 @@ const handleDataConstituentProperties = sectionHandler(
 
     let unexpectedNode = findUnexpectedNode(
       section,
-      [heading, expectedIntroTextP, ...lis],
+      [section.children[0], expectedIntroTextP, ...lis],
       [expectedUl]
     );
     if (unexpectedNode !== null) {
@@ -75,10 +74,10 @@ const handleDataConstituentProperties = sectionHandler(
         "No other elements allowed in constituent properties",
         "unexpected-content"
       );
-      return null;
+      return false;
     }
 
-    return heading;
+    return true;
   }
 );
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-constructor.js
@@ -51,7 +51,7 @@ function handleDataConstructor(tree, logger) {
   // Otherwise they must include a link to a constructor
 
   // Check common link list structure
-  let ok = checkLinkList("Constructor", tree, logger);
+  let ok = checkLinkList(section, logger);
 
   // This link list is only allowed one entry
   const dts = select.selectAll("dt", section);

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -49,43 +49,34 @@ function checkExample(exampleNodes, logger) {
 /**
  * Handler for the `data.examples` ingredient.
  */
-function handleDataExamples(tree, logger) {
-  const id = "Examples";
-  const body = select.select(`body`, tree);
-  const heading = select.select(`h2#${id}`, body);
-
-  // The document must have an H2 section "Examples"
-  if (heading === null) {
-    logger.expected(body, `h2#${id}`, "expected-heading");
-    return null;
-  }
-
-  const examplesSection = utils.sliceSection(heading, body);
-
-  // The "Examples" section must contain at least one H3
-  const exampleTitles = select.selectAll("h3", examplesSection);
-  if (exampleTitles.length === 0) {
-    logger.fail(
-      examplesSection,
-      "No H3-demarcated examples found",
-      "missing-example-h3"
-    );
-    return null;
-  }
-
-  for (const exampleTitle of exampleTitles) {
-    // Extract and check each example
-    const exampleSection = utils.sliceBetween(
-      exampleTitle,
-      (node) => node.tagName === "h3",
-      examplesSection
-    );
-    if (!checkExample(exampleSection, logger)) {
-      return null;
+const handleDataExamples = utils.sectionHandler(
+  "Examples",
+  (section, logger) => {
+    // The "Examples" section must contain at least one H3
+    const exampleTitles = select.selectAll("h3", section);
+    if (exampleTitles.length === 0) {
+      logger.fail(
+        section,
+        "No H3-demarcated examples found",
+        "missing-example-h3"
+      );
+      return false;
     }
-  }
 
-  return heading;
-}
+    for (const exampleTitle of exampleTitles) {
+      // Extract and check each example
+      const exampleSection = utils.sliceBetween(
+        exampleTitle,
+        (node) => node.tagName === "h3",
+        section
+      );
+      if (!checkExample(exampleSection, logger)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+);
 
 module.exports = handleDataExamples;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-definition.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-definition.js
@@ -3,8 +3,6 @@ const { findUnexpectedNode, isMacro, sectionHandler } = require("./utils");
 const handleDataFormalDefinition = sectionHandler(
   "Formal_definition",
   (section, logger) => {
-    const heading = section.children[0];
-
     // Find the first P with a CSSInfo macro as one of its children
     let expectedMacro;
     let expectedP = section.children.find((node) => {
@@ -24,13 +22,13 @@ const handleDataFormalDefinition = sectionHandler(
         "CSSInfo macro paragraph",
         "expected-cssinfo-macro"
       );
-      return null;
+      return false;
     }
 
     // The section must contain only a heading and `<p>{{CSSInfo}}</p>`
     const extraneousNode = findUnexpectedNode(
       section,
-      [heading],
+      [section.children[0]],
       [expectedP, expectedMacro]
     );
     if (extraneousNode !== null) {
@@ -39,10 +37,10 @@ const handleDataFormalDefinition = sectionHandler(
         "No other elements allowed in data.formal_definition",
         "expected-macro-only"
       );
-      return null;
+      return false;
     }
 
-    return heading;
+    return true;
   }
 );
 

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-formal-syntax.js
@@ -5,60 +5,53 @@ const {
   findUnexpectedNode,
   isMacro,
   isWhiteSpaceTextNode,
-  sliceSection,
+  sectionHandler,
 } = require("./utils");
 
-function handleDataFormalSyntax(tree, logger) {
-  const id = "Formal_syntax";
-  const body = select(`body`, tree);
-  const heading = select(`h2#${id}`, body);
-
-  if (heading === null) {
-    logger.expected(body, `h2#${id}`, "expected-heading");
-    return null;
-  }
-
-  // Section must contain pre.syntaxbox
-  const section = sliceSection(heading, body);
-  const expectedSyntaxBox = select("pre.syntaxbox", section);
-  if (expectedSyntaxBox === null) {
-    logger.expected(section, "pre.syntaxbox", "expected-pre.syntaxbox");
-    return null;
-  }
-
-  // pre.syntaxbox must contain CSSSyntax macro
-  let expectedMacro = null;
-  visit(
-    expectedSyntaxBox,
-    (node) => !isWhiteSpaceTextNode(node),
-    (node) => {
-      if (isMacro(node, "CSSSyntax")) {
-        expectedMacro = node;
-        return visit.EXIT;
-      }
+const handleDataFormalSyntax = sectionHandler(
+  "Formal_syntax",
+  (section, logger) => {
+    // Section must contain pre.syntaxbox
+    const expectedSyntaxBox = select("pre.syntaxbox", section);
+    if (expectedSyntaxBox === null) {
+      logger.expected(section, "pre.syntaxbox", "expected-pre.syntaxbox");
+      return false;
     }
-  );
-  if (expectedMacro === null) {
-    logger.expected(section, "CSSSyntax macro", "expected-macro");
-    return null;
-  }
 
-  // The section must contain only the `h2`, `pre.syntaxbox`, and macro call
-  const extraneousNode = findUnexpectedNode(
-    section,
-    [heading],
-    [expectedSyntaxBox, expectedMacro]
-  );
-  if (extraneousNode !== null) {
-    logger.fail(
-      extraneousNode,
-      "No other elements allowed in data.formal_syntax",
-      "syntax-only"
+    // pre.syntaxbox must contain CSSSyntax macro
+    let expectedMacro = null;
+    visit(
+      expectedSyntaxBox,
+      (node) => !isWhiteSpaceTextNode(node),
+      (node) => {
+        if (isMacro(node, "CSSSyntax")) {
+          expectedMacro = node;
+          return visit.EXIT;
+        }
+      }
     );
-    return null;
-  }
+    if (expectedMacro === null) {
+      logger.expected(section, "CSSSyntax macro", "expected-macro");
+      return false;
+    }
 
-  return heading;
-}
+    // The section must contain only the `h2`, `pre.syntaxbox`, and macro call
+    const extraneousNode = findUnexpectedNode(
+      section,
+      [section.children[0]],
+      [expectedSyntaxBox, expectedMacro]
+    );
+    if (extraneousNode !== null) {
+      logger.fail(
+        extraneousNode,
+        "No other elements allowed in data.formal_syntax",
+        "syntax-only"
+      );
+      return false;
+    }
+
+    return true;
+  }
+);
 
 module.exports = handleDataFormalSyntax;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
@@ -17,17 +17,14 @@ function containsLinkOrXRef(node) {
   return false;
 }
 
-function checkLinkList(id, tree, logger) {
-  const body = select.select("body", tree);
-
-  const heading = select.select(`h2#${id}`, body);
-  // This is an optional ingredient, so if there's no `h2`,
-  // assume that the page intends to omit it.
-  if (heading === null) {
-    return null;
-  }
-
-  const section = utils.sliceSection(heading, body);
+/**
+ * Check whether a section contains a well-formed definition list.
+ *
+ * @param {*} section - a section tree (typically via `utils.sectionHandler()`)
+ * @param {*} logger - a logger object (typically via `utils.sectionHandler()`)
+ * @returns {Boolean} - `true` for success, or `false` for failure
+ */
+function checkLinkList(section, logger) {
   // The first element is always the `h2`, which we are not interested in
   const children = section.children.slice(1);
 
@@ -36,11 +33,11 @@ function checkLinkList(id, tree, logger) {
   const elements = children.filter((child) => child.type === "element");
   if (elements.length !== 1 || elements[0].tagName !== "dl") {
     logger.fail(
-      body,
+      section.children[0],
       "Link list must contain a single DL element and no other elements",
       "only-single-dl-element-in-link-list"
     );
-    return null;
+    return false;
   }
 
   // At the top level, if a link list contains text nodes,
@@ -54,7 +51,7 @@ function checkLinkList(id, tree, logger) {
         "Text nodes in list of links top level may only contain newlines",
         "text-nodes-in-link-list"
       );
-      return null;
+      return false;
     }
   }
 
@@ -64,11 +61,11 @@ function checkLinkList(id, tree, logger) {
   const dts = select.selectAll("dt", dl);
   if (dts.length === 0) {
     logger.fail(
-      body,
+      dl,
       "Link list dl must contain at least one dt",
       "dl-must-contain-dt"
     );
-    return null;
+    return false;
   }
 
   // Each <dt> must contain only a single <a> element or a call to jsxref.
@@ -79,7 +76,7 @@ function checkLinkList(id, tree, logger) {
         "dt elements in link lists must contain a single anchor element or xref macro call",
         "only-single-anchor-element-or-xref-in-link-list-dt"
       );
-      return null;
+      return false;
     }
   }
 
@@ -92,7 +89,7 @@ function checkLinkList(id, tree, logger) {
         "code elements in dt elements in link lists must contain a single text node",
         "only-single-text-node-element-in-link-list-code"
       );
-      return null;
+      return false;
     }
   }
 
@@ -110,7 +107,7 @@ function checkLinkList(id, tree, logger) {
     previousTitle = dtCode.children[0].value;
   }
 
-  return heading;
+  return true;
 }
 
 module.exports = checkLinkList;

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/link-list-checker.js
@@ -103,6 +103,7 @@ function checkLinkList(section, logger) {
         "Links in link lists must be listed in alphabetical order",
         "link-list-alpha-order"
       );
+      return false;
     }
     previousTitle = dtCode.children[0].value;
   }

--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/utils.js
@@ -145,16 +145,19 @@ function Logger(file, source, recipeName, ingredient) {
  * @callback handleSectionFn
  * @param {Object} section - the tree for the section
  * @param {Logger} logger - the logger from the ingredient handler
- * @returns {Object|null} - the node marking the position of the ingredient or `null`
+ * @returns {Boolean} - whether the section passed all checks
  */
 
 /**
  * Create an ingredient handler that expects an H2 section.
  *
- * This is a convenience wrapper for finding an H2 by its ID, slicing the corresponding section, and doing further checks on that section.
+ * This is a convenience wrapper for finding an H2 by its ID, slicing the
+ * corresponding section, and doing further checks on that section.
  *
  * @param {String} id - the ID for an H2
- * @param {handleSectionFn} handleSectionFn - an ingredient handler with extra `heading` and `section` parameters
+ * @param {handleSectionFn} handleSectionFn - an ingredient handler with extra
+ * `heading` and `section` parameters; it should return a truthy or fasly value
+ * for success or failure
  * @param {Boolean} [optional] - whether this section is optional
  * @returns {Function} an ingredient handler
  */
@@ -173,8 +176,10 @@ function sectionHandler(id, handleSectionFn, optional = false) {
 
     const section = sliceSection(heading, body);
 
-    // Pass section details into actual handler
-    return handleSectionFn(section, logger);
+    if (!handleSectionFn(section, logger)) {
+      return null;
+    }
+    return heading;
   };
 }
 

--- a/scripts/scraper-ng/test/ingredient-data.static_methods.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.static_methods.test.js
@@ -1,4 +1,8 @@
-const { process } = require("./framework/utils");
+const {
+  process,
+  expectNullPosition,
+  expectPositionElement,
+} = require("./framework/utils");
 
 const sources = {
   no_static_methods: `<p>Some content.</p>
@@ -80,6 +84,11 @@ describe("data.static_methods", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file.messages[0].ruleId).toEqual("jsxref");
+    expectPositionElement(
+      file.data.ingredients[0],
+      "data.static_methods?",
+      "h2"
+    );
   });
 
   test("invalid static methods with empty heading", () => {
@@ -92,6 +101,7 @@ describe("data.static_methods", () => {
     expect(file).hasMessageWithId(
       "data.static_methods?/only-single-dl-element-in-link-list"
     );
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 
   test("invalid static methods with empty dl", () => {
@@ -99,6 +109,7 @@ describe("data.static_methods", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId("data.static_methods?/dl-must-contain-dt");
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 
   test("invalid static methods with extra non-dl", () => {
@@ -111,6 +122,7 @@ describe("data.static_methods", () => {
     expect(file).hasMessageWithId(
       "data.static_methods?/only-single-dl-element-in-link-list"
     );
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 
   test("invalid static methods with multiple dl", () => {
@@ -123,6 +135,7 @@ describe("data.static_methods", () => {
     expect(file).hasMessageWithId(
       "data.static_methods?/only-single-dl-element-in-link-list"
     );
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 
   test("invalid static methods with invalid dt", () => {
@@ -135,6 +148,7 @@ describe("data.static_methods", () => {
     expect(file).hasMessageWithId(
       "data.static_methods?/only-single-anchor-element-or-xref-in-link-list-dt"
     );
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 
   test("invalid static methods with unordered dl", () => {
@@ -145,5 +159,6 @@ describe("data.static_methods", () => {
 
     expect(file.messages.length).toBe(1);
     expect(file).hasMessageWithId("data.static_methods?/link-list-alpha-order");
+    expectNullPosition(file.data.ingredients[0], "data.static_methods?");
   });
 });


### PR DESCRIPTION
This PR completes a refactor of the ingredient handlers which consume specific H2 sections from a page.

## What this does

Previously, we added a wrapper for ingredient handlers with a signature like this: `sectionHandler(sectionId, handlerFn, optional)`. The inner `handlerFn` is written much like the existing ingredient handlers, except that it receives a `section` tree and a `logger` object, instead of the complete page tree. If the section can't be found (i.e., the H2 is missing, `sectionHandler` returns the appropriate error.

New in this PR: if the inner callback function returns `true` (or some other truthy value, for success), then the wrapper handles returning the correct position H2 node. If the callback function returns `false` (or some other falsy value), then the wrapper returns the correct null value.

Additionally, in the course of refactoring, I spotted a suspected bug, confirmed it, and fixed it.

## Interesting commits 

Most of the changes are rather mechanical: wrapping the existing handler functions and changing return values to the right type. Occasionally, I had to substitute an error message's position node with one from the section context.

Unfortunately, it touches lots of lines, thanks to changes in indentation; the total number of lines of code is reduced, excluding tests.

Here are some highlights:

* d40a21d - adds the position node handling to `sectionHandler`
* 9421959 and d35f879 - the most complex refactor, to `checkLinkList`, class methods, and constructors
* c6f0922 and 9a6f74f - adds to tests for a bug I spotted in the link list checker, and fixes it
