### PR TITLE
Make tag handling case insensitive

### DIFF
--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -112,7 +112,7 @@ const signatures = [
  */
 function identifyRecipesPlugin() {
   return function transformer(tree, file) {
-    const tagSet = new Set(file.data.tags);
+    const tagSet = new Set(file.data.tags.map((tag) => tag.toLowerCase()));
     const recipes = [];
 
     for (const { recipePath, conditions } of signatures) {
@@ -148,7 +148,7 @@ function recipe(name) {
  */
 function hasAll(set, subset) {
   for (let elem of subset) {
-    if (!set.has(elem)) {
+    if (!set.has(elem.toLowerCase())) {
       return false;
     }
   }


### PR DESCRIPTION
In https://github.com/mdn/sprints/issues/3171 I've been working on adding tags to pages so the linter can map them to recipes.

But there's a snag: Kuma treats tags case-insensitively. So if there's already a tag "media feature" and we add a tag "Media feature", Kuma will convert the new "Media feature" to "media feature", and the linter won't recognize it, because the linter does a case-sensitive compare between tag values and the values in identify-recipes.js.

I thought that removing all "media feature" tags would somehow reset things and allow me to use "Media feature", but that doesn't seem to work. So this PR instead makes the linter convert all tag values and comparators to lowercase before comparing. 