### PR TITLE
Add recipe for CSS keywords

### DIFF
--- a/recipes/css-keyword.yaml
+++ b/recipes/css-keyword.yaml
@@ -1,0 +1,12 @@
+data:
+  - title
+  - short_title?
+  - mdn_url
+body:
+  - prose.short_description
+  - prose.description?
+  - prose.*
+  - data.examples
+  - data.specifications
+  - data.browser_compatibility
+  - prose.see_also

--- a/scripts/scraper-ng/plugins/identify-recipes.js
+++ b/scripts/scraper-ng/plugins/identify-recipes.js
@@ -26,6 +26,12 @@ const signatures = [
     },
   },
   {
+    recipePath: recipe("css-keyword"),
+    conditions: {
+      tags: ["CSS", "Keyword"],
+    },
+  },
+  {
     recipePath: recipe("css-media-feature"),
     conditions: {
       tags: ["CSS", "Media feature"],


### PR DESCRIPTION
As discussed in https://github.com/mdn/sprints/issues/3171#issuecomment-655197948, this adds a new recipe for CSS keywords. I've tagged the keyword pages:

https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/inherit
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/initial
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/revert
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/unset

...with "Keyword", and with this PR and that change we now see only two "Recipe missing" messages.