### PR TITLE
Fix noisy EmbedLiveSample linter message

### DIFF
--- a/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
+++ b/scripts/scraper-ng/rules/html-require-recipe-ingredients/ingredient-handlers/data-examples.js
@@ -21,6 +21,7 @@ function checkExample(exampleNodes, logger) {
           "nodes-after-live-sample"
         );
         ok = false;
+        return visit.EXIT;
       }
     }
     if (utils.isMacro(node, "EmbedLiveSample")) {

--- a/scripts/scraper-ng/test/ingredient-data.examples.test.js
+++ b/scripts/scraper-ng/test/ingredient-data.examples.test.js
@@ -42,7 +42,8 @@ const sources = {
 
   nodes_after_live_sample: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>
-  {{EmbedLiveSample("An_example")}}Some more content`,
+  {{EmbedLiveSample("An_example")}}
+  <p>Some more <em>emphatic</em> content</p>`,
 
   live_sample_id_mismatch: `<h2 id="Examples">Examples</h2>
 <h3 id="An_example">An example</h3>


### PR DESCRIPTION
I ran into a little oddity while cleaning up some CSS pages today. If you run the linter on a page with multiple elements after an example's `EmbedLiveSample` macro call, then you'll get a linter message for _every_ node after the macro call. It looks a bit like this:

```shell
$ node scripts/scraper-ng https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/writing-mode --verbose
Preparing to lint 1 pages…
Fetching /en-US/docs/Web/CSS/writing-mode
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/writing-mode
    171:1-171:134  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
     171:4-171:90  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
   171:90-171:115  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
   171:96-171:108  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
  171:115-171:130  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
    173:1-173:139  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient
    173:4-173:135  error  EmbedLiveSample must be final node  css-property/data.examples/nodes-after-live-sample  html-require-ingredient

✖ 7 errors
```

Although it was true there were several elements after the call, it was rather noisy for what's really just one _problem_.

In this PR, I've changed the source for the test for this message to contain additional elements after the macro call. Having produced a failing test, I modified the linter to bail out after hitting the first offending node.